### PR TITLE
Initialize Supabase client in App.vue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -40,6 +40,7 @@ import { ref, onMounted, watch } from 'vue';
 import ItemForm from './components/ItemForm.vue';
 import ItemGrid from './components/ItemGrid.vue';
 import { Item, mapRecordToItem, defaultItems } from './types/item';
+import { supabase } from './supabaseClient';
 
 // Items state
 const items = ref<Item[]>([]);
@@ -47,7 +48,7 @@ const showForm = ref(false);
 const isLoading = ref(true);
 const serverError = ref('');
 
-// Fetch items from Airtable
+// Fetch items from Supabase
 async function fetchItems() {
   isLoading.value = true;
   serverError.value = '';

--- a/src/components/ItemForm.vue
+++ b/src/components/ItemForm.vue
@@ -93,13 +93,7 @@
 import { ref, computed } from 'vue';
 import { statusOptions } from '../types/item';
 import type { Item } from '../types/item';
-import { createClient } from '@supabase/supabase-js';
-
-// Initialize Supabase client using your Supabase URL and anon key
-const supabaseUrl = 'https://ielukqallxtceqmobmvpv.supabase.co';
-const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImllbHVrcWFsbHh0Y2VxbW9ibXZwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg4MzA2NzIsImV4cCI6MjA2NDQwNjY3Mn0.-e-JULBAaIdzCkDBQaZiTBdWqsHkHYWpxrsrKktPfyQ';
-
-const supabase = createClient(supabaseUrl, supabaseKey);
+import { supabase } from '../supabaseClient';
 
 const emit = defineEmits<{
   (e: 'item-added', item: Item): void;

--- a/src/supabaseClient.ts
+++ b/src/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = 'https://ielukqallxtceqmobmvpv.supabase.co';
+const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImllbHVrcWFsbHh0Y2VxbW9ibXZwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg4MzA2NzIsImV4cCI6MjA2NDQwNjY3Mn0.-e-JULBAaIdzCkDBQaZiTBdWqsHkHYWpxrsrKktPfyQ';
+
+export const supabase = createClient(supabaseUrl, supabaseKey);


### PR DESCRIPTION
## Summary
- centralize Supabase initialization in `src/supabaseClient.ts`
- import and use this client in `App.vue` and `ItemForm.vue`
- update comment to reflect Supabase usage

## Testing
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_684ae4c3a950832082ec8b9a3aa0b940