### PR TITLE
Add Supabase environment variable definitions

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -4,6 +4,8 @@
 interface ImportMetaEnv {
   readonly VITE_APP_TITLE: string
   // more env variables...
+  readonly VITE_SUPABASE_URL: string
+  readonly VITE_SUPABASE_KEY: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- expand `env.d.ts` so TypeScript knows about `VITE_SUPABASE_URL` and `VITE_SUPABASE_KEY`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b431a88388320bcf7eebfb639562e