### PR TITLE
Add env validation for Supabase client

### DIFF
--- a/src/supabaseClient.ts
+++ b/src/supabaseClient.ts
@@ -4,5 +4,13 @@ import { createClient } from '@supabase/supabase-js';
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseKey = import.meta.env.VITE_SUPABASE_KEY;
 
+if (!supabaseUrl || !supabaseKey) {
+  const missingVars: string[] = [];
+  if (!supabaseUrl) missingVars.push('VITE_SUPABASE_URL');
+  if (!supabaseKey) missingVars.push('VITE_SUPABASE_KEY');
+  const message = `Missing environment variables: ${missingVars.join(', ')}`;
+  console.warn(message);
+  throw new Error(message);
+}
 
 export const supabase = createClient(supabaseUrl, supabaseKey);


### PR DESCRIPTION
## Summary
- validate Supabase URL and key before creating client

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b44aadf64832083e39ad00c190e00