### PR TITLE
Display and edit item date

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A single-page application built with Vue 3 and TypeScript for tracking items wit
 
 - Add items with images, names, and detailed descriptions
 - Track item sales status (Not Sold / Sold / Sold & Paid)
+- Record when each item was added and display this date
 - View all items in a responsive grid layout
 - Persistent data storage using localStorage
 - Fully responsive design

--- a/src/App.vue
+++ b/src/App.vue
@@ -164,19 +164,34 @@ const handleItemUpdated = (updated: Item) => {
 };
 
 // Handle updating an item's status
-const updateItemStatus = (id: string, status: "not_sold" | "sold" | "sold_paid") => {
-  console.log('Updating item status:', id, status);
-  
-  // Find the item and update its status
-  const itemIndex = items.value.findIndex(item => item.id === id);
-  if (itemIndex !== -1) {
-    // Create a new array to ensure reactivity
-    const updatedItems = [...items.value];
-    updatedItems[itemIndex] = {
-      ...updatedItems[itemIndex],
-      status: status
-    };
-    items.value = updatedItems;
+const updateItemStatus = async (
+  id: string,
+  status: "not_sold" | "sold" | "sold_paid"
+) => {
+  console.log("Updating item status:", id, status);
+
+  try {
+    const { data, error } = await supabase
+      .from("items")
+      .update({ status })
+      .eq("id", id)
+      .select()
+      .single();
+
+    if (error) throw error;
+
+    const itemIndex = items.value.findIndex(item => item.id === id);
+    if (itemIndex !== -1 && data) {
+      const updatedItems = [...items.value];
+      updatedItems[itemIndex] = {
+        ...updatedItems[itemIndex],
+        status: data.status,
+      };
+      items.value = updatedItems;
+    }
+  } catch (err: any) {
+    console.error(err);
+    alert("❌ Error updating status: " + err.message);
   }
 };
 

--- a/src/components/EditItemForm.vue
+++ b/src/components/EditItemForm.vue
@@ -35,6 +35,15 @@
     </div>
 
     <div class="mb-4">
+      <label class="block text-gray-700 font-medium mb-2">Date Added</label>
+      <input
+        v-model="form.dateAdded"
+        type="date"
+        class="w-full px-3 py-2 border border-gray-300 rounded"
+      >
+    </div>
+
+    <div class="mb-4">
       <label class="block text-gray-700 font-medium mb-2">Image</label>
       <input
         type="file"
@@ -113,6 +122,7 @@ const form = ref({
   status: props.item.status,
   location: props.item.location,
   price: props.item.price,
+  dateAdded: props.item.dateAdded.slice(0, 10),
 });
 
 const selectedFile = ref<File | null>(null);
@@ -127,6 +137,7 @@ watch(
       status: val.status,
       location: val.location,
       price: val.price,
+      dateAdded: val.dateAdded.slice(0, 10),
     };
     previewUrl.value = val.imageUrl;
     selectedFile.value = null;
@@ -163,6 +174,7 @@ async function handleSubmit() {
         location: form.value.location,
         price: form.value.price,
         image_url: imageUrl,
+        date_added: new Date(form.value.dateAdded).toISOString(),
       })
       .eq('id', props.item.id)
       .select()

--- a/src/components/ItemCard.vue
+++ b/src/components/ItemCard.vue
@@ -1,13 +1,5 @@
 <template>
   <div class="bg-white rounded-lg shadow-md overflow-hidden">
-    <!-- Debug info to see what's happening -->
-    <div
-      v-if="!item.imageUrl"
-      class="p-2 bg-red-100 text-xs"
-    >
-      No image URL available: {{ JSON.stringify(item) }}
-    </div>
-    
     <!-- Image display with local fallback support -->
     <div
       v-if="item.imageUrl"
@@ -43,8 +35,14 @@
       <h3 class="text-lg font-semibold mb-2">
         {{ item.name }}
       </h3>
-      <p class="text-gray-600 text-sm mb-3">
+      <p class="text-gray-600 text-sm mb-1">
         {{ item.details }}
+      </p>
+      <p class="text-gray-600 text-sm mb-1">
+        Location: {{ item.location }}
+      </p>
+      <p class="text-gray-500 text-xs mb-3">
+        Added {{ formattedDate }}
       </p>
       
       <!-- Status controls -->
@@ -112,15 +110,12 @@ const emit = defineEmits<{
 const imageError = ref(false);
 
 const handleImageError = () => {
-  console.log(`Image failed to load: ${props.item.imageUrl}`);
   imageError.value = true;
 };
 
-// FIX: Update the handleStatusChange function to properly emit both parameters
 const handleStatusChange = (event: Event) => {
   const target = event.target as HTMLSelectElement;
   const newStatus = target.value as "not_sold" | "sold" | "sold_paid";
-  console.log(`Updating status for item ${props.item.id} to ${newStatus}`);
   emit('update-status', props.item.id, newStatus);
 };
 
@@ -131,6 +126,14 @@ const handleDelete = () => {
 const handleEdit = () => {
   emit('edit-item', props.item);
 };
+
+const formattedDate = computed(() => {
+  try {
+    return new Date(props.item.dateAdded).toLocaleDateString();
+  } catch {
+    return props.item.dateAdded;
+  }
+});
 
 const statusLabel = computed(() => {
   const option = statusOptions.find(opt => opt.value === props.item.status);


### PR DESCRIPTION
## Summary
- show the item's added date on each card
- edit the date in the update form
- mention the date-added feature in README
- remove debug code and display location on item cards
- persist updated status in the database

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c35c6b2f48320adf19e23684db61b