### PR TITLE
Add sales chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A single-page application built with Vue 3 and TypeScript for tracking items wit
 
 - Add items with images, names, prices, locations, and detailed descriptions
 - Track item sales status (Not Sold / Sold / Sold & Paid)
+- Simple statistics for Sold and Sold & Paid counts stored in Supabase, updated automatically when items change
+- Bar chart showing how many items were sold in the last 30 days, 6 months, and year
 - Record when each item was added and display this date
 - View all items in a responsive grid layout
 - Persistent data storage using localStorage

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "dependencies": {
                 "@imagekit/vue": "^4.0.0",
                 "@supabase/supabase-js": "^2.49.8",
+                "chart.js": "^4.4.1",
                 "imagekit": "^4.1.3",
                 "vue": "^3.3.4",
                 "vue-router": "^4.5.1"
@@ -730,6 +731,12 @@
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
+        },
+        "node_modules/@kurkle/color": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+            "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+            "license": "MIT"
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -1975,6 +1982,18 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/chart.js": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.1.tgz",
+            "integrity": "sha512-C74QN1bxwV1v2PEujhmKjOZ7iUM4w6BWs23Md/6aOZZSlwMzeCIDGuZay++rBgChYru7/+QFeoQW0fQoP534Dg==",
+            "license": "MIT",
+            "dependencies": {
+                "@kurkle/color": "^0.3.0"
+            },
+            "engines": {
+                "pnpm": ">=7"
             }
         },
         "node_modules/chokidar": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dependencies": {
         "@imagekit/vue": "^4.0.0",
         "@supabase/supabase-js": "^2.49.8",
+        "chart.js": "^4.4.1",
         "imagekit": "^4.1.3",
         "vue": "^3.3.4",
         "vue-router": "^4.5.1"

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,6 +3,8 @@
     <h1 class="text-3xl font-bold text-center mb-8">
       Item Tracker
     </h1>
+    <StatsDisplay :stats="currentStats" />
+    <StatsChart :items="items" />
     
     <!-- Show server error if any -->
     <div
@@ -59,9 +61,12 @@ import { ref, onMounted, watch } from 'vue';
 import ItemForm from './components/ItemForm.vue';
 import EditItemForm from './components/EditItemForm.vue';
 import ItemGrid from './components/ItemGrid.vue';
+import StatsDisplay from './components/StatsDisplay.vue';
+import StatsChart from './components/StatsChart.vue';
 import type { Item } from './types/item';
 import { mapRecordToItem, defaultItems } from './types/item';
 import { supabase } from './supabaseClient';
+import { calculateStats, saveStats, type Stats } from './utils/stats';
 
 // Items state
 const items = ref<Item[]>([]);
@@ -69,6 +74,7 @@ const showForm = ref(false);
 const isLoading = ref(true);
 const serverError = ref('');
 const editingItem = ref<Item | null>(null);
+const currentStats = ref<Stats>({ sold: 0, sold_paid: 0 });
 
 
 
@@ -86,10 +92,14 @@ async function fetchItems() {
 
     if (error) throw error;
     items.value = data.map(mapRecordToItem); // adjust mapRecordToItem if needed
+    const stats = calculateStats(items.value);
+    currentStats.value = stats;
+    await saveStats(stats);
   } catch (err: any) {
     console.error('Error fetching items:', err);
     serverError.value = 'Error fetching items';
     items.value = [...defaultItems];
+    currentStats.value = calculateStats(items.value);
   } finally {
     isLoading.value = false;
   }
@@ -124,7 +134,11 @@ watch(items, () => {
       }
       
       console.log('Items saved to server successfully');
-      
+
+      const stats = calculateStats(items.value);
+      currentStats.value = stats;
+      await saveStats(stats);
+
     } catch (error) {
       console.error('Error saving to server:', error);
       serverError.value = 'Failed to save items to server. Saving locally as fallback.';
@@ -133,6 +147,9 @@ watch(items, () => {
       try {
         localStorage.setItem('itemTrackerItems', JSON.stringify(items.value));
         console.log('Items saved to localStorage as fallback');
+        const stats = calculateStats(items.value);
+        currentStats.value = stats;
+        await saveStats(stats);
       } catch (localError) {
         console.error('Error with localStorage fallback:', localError);
       }
@@ -144,6 +161,7 @@ watch(items, () => {
 const handleItemAdded = (newItem: Item) => {
   console.log('Adding new item:', newItem);
   items.value = [...items.value, newItem]; // Create a new array to ensure reactivity
+  currentStats.value = calculateStats(items.value);
   showForm.value = false;
 };
 
@@ -160,6 +178,7 @@ const handleItemUpdated = (updated: Item) => {
     const updatedItems = [...items.value];
     updatedItems[index] = updated;
     items.value = updatedItems;
+    currentStats.value = calculateStats(items.value);
   }
   editingItem.value = null;
 };
@@ -189,6 +208,7 @@ const updateItemStatus = async (
         status: data.status,
       };
       items.value = updatedItems;
+      currentStats.value = calculateStats(items.value);
     }
   } catch (err: any) {
     console.error(err);
@@ -200,6 +220,7 @@ const updateItemStatus = async (
 const deleteItem = (id: string) => {
   console.log('Deleting item:', id);
   items.value = items.value.filter(item => item.id !== id);
+  currentStats.value = calculateStats(items.value);
 };
 </script>
 

--- a/src/components/StatsChart.vue
+++ b/src/components/StatsChart.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="mb-6">
+    <canvas ref="canvas" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, watch } from 'vue';
+import { Chart, registerables } from 'chart.js';
+import type { Item } from '../types/item';
+import { calculatePeriodStats, type PeriodStats } from '../utils/stats';
+
+const props = defineProps<{ items: Item[] }>();
+
+const canvas = ref<HTMLCanvasElement | null>(null);
+let chart: Chart | null = null;
+
+function buildData(items: Item[]): number[] {
+  const stats: PeriodStats = calculatePeriodStats(items);
+  return [stats.last30Days, stats.last6Months, stats.lastYear];
+}
+
+function renderChart() {
+  if (!canvas.value) return;
+  const data = buildData(props.items);
+
+  if (chart) {
+    chart.data.datasets[0].data = data;
+    chart.update();
+    return;
+  }
+
+  Chart.register(...registerables);
+  chart = new Chart(canvas.value, {
+    type: 'bar',
+    data: {
+      labels: ['30 days', '6 months', '1 year'],
+      datasets: [
+        {
+          label: 'Items Sold',
+          backgroundColor: '#60a5fa',
+          data
+        }
+      ]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        y: {
+          beginAtZero: true,
+          ticks: { precision: 0 }
+        }
+      }
+    }
+  });
+}
+
+onMounted(() => {
+  renderChart();
+});
+
+watch(
+  () => props.items,
+  () => {
+    renderChart();
+  },
+  { deep: true }
+);
+</script>
+
+<style scoped>
+div {
+  height: 300px;
+}
+</style>

--- a/src/components/StatsDisplay.vue
+++ b/src/components/StatsDisplay.vue
@@ -1,0 +1,32 @@
+<template>
+  <div class="flex space-x-4 mb-6">
+    <div class="bg-gray-100 p-4 rounded text-center">
+      <p class="text-sm text-gray-600">
+        Sold
+      </p>
+      <p class="text-xl font-bold">
+        {{ stats.sold }}
+      </p>
+    </div>
+    <div class="bg-gray-100 p-4 rounded text-center">
+      <p class="text-sm text-gray-600">
+        Sold &amp; Paid
+      </p>
+      <p class="text-xl font-bold">
+        {{ stats.sold_paid }}
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Stats } from '../utils/stats';
+
+defineProps<{
+  stats: Stats
+}>();
+</script>
+
+<style scoped>
+/* Basic styling */
+</style>

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -1,0 +1,67 @@
+import { supabase } from '../supabaseClient';
+import type { Item } from '../types/item';
+
+export interface Stats {
+  sold: number;
+  sold_paid: number;
+}
+
+export interface PeriodStats {
+  last30Days: number;
+  last6Months: number;
+  lastYear: number;
+}
+
+const BUCKET = 'stats';
+const FILE_PATH = 'current-stats.json';
+
+export function calculateStats(items: Item[]): Stats {
+  const sold = items.filter(i => i.status === 'sold').length;
+  const sold_paid = items.filter(i => i.status === 'sold_paid').length;
+  return { sold, sold_paid };
+}
+
+export function calculatePeriodStats(items: Item[]): PeriodStats {
+  const now = new Date();
+  const d30 = new Date(now);
+  d30.setDate(now.getDate() - 30);
+  const m6 = new Date(now);
+  m6.setMonth(now.getMonth() - 6);
+  const y1 = new Date(now);
+  y1.setFullYear(now.getFullYear() - 1);
+
+  const countSince = (date: Date) =>
+    items.filter(i => (i.status === 'sold' || i.status === 'sold_paid') && new Date(i.dateAdded) >= date).length;
+
+  return {
+    last30Days: countSince(d30),
+    last6Months: countSince(m6),
+    lastYear: countSince(y1)
+  };
+}
+
+export async function fetchStats(): Promise<Stats | null> {
+  const { data, error } = await supabase.storage.from(BUCKET).download(FILE_PATH);
+  if (error || !data) {
+    console.error('Error downloading stats:', error);
+    return null;
+  }
+  try {
+    const text = await data.text();
+    return JSON.parse(text) as Stats;
+  } catch (err) {
+    console.error('Error parsing stats:', err);
+    return null;
+  }
+}
+
+export async function saveStats(stats: Stats): Promise<void> {
+  const blob = new Blob([JSON.stringify(stats)], { type: 'application/json' });
+  const { error } = await supabase.storage.from(BUCKET).upload(FILE_PATH, blob, {
+    upsert: true,
+    contentType: 'application/json'
+  });
+  if (error) {
+    console.error('Error uploading stats:', error);
+  }
+}


### PR DESCRIPTION
## Summary
- install `chart.js`
- compute sales counts for 30 days, 6 months and 1 year
- show a bar chart of sold items in a new `StatsChart` component
- render the chart alongside summary stats
- document the new chart feature

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c4a3fc8588320991a92668c0d8873