### PR TITLE
Fix Stats components and remove merge leftovers

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,9 +5,8 @@
     </h1>
 
     <StatsDisplay :stats="currentStats" />
-    <StatsChart :items="items" />
 
-    <StatsDisplay />
+    <StatsChart :items="items" />
 
     
     <!-- Show server error if any -->

--- a/src/components/StatsDisplay.vue
+++ b/src/components/StatsDisplay.vue
@@ -20,26 +20,23 @@
 </template>
 
 <script setup lang="ts">
+import { ref, onMounted, computed } from 'vue';
+import { fetchStats, type Stats } from '../utils/stats';
 
-import type { Stats } from '../utils/stats';
+const props = defineProps<{ stats?: Stats }>();
 
-defineProps<{
-  stats: Stats
-}>();
-
-import { ref, onMounted } from 'vue';
-import type { Stats } from '../utils/stats';
-import { fetchStats } from '../utils/stats';
-
-const stats = ref<Stats>({ sold: 0, sold_paid: 0 });
+const fetchedStats = ref<Stats>({ sold: 0, sold_paid: 0 });
 
 onMounted(async () => {
-  const stored = await fetchStats();
-  if (stored) {
-    stats.value = stored;
+  if (!props.stats) {
+    const stored = await fetchStats();
+    if (stored) {
+      fetchedStats.value = stored;
+    }
   }
 });
 
+const stats = computed(() => props.stats ?? fetchedStats.value);
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- clean up `StatsDisplay` so stats can be passed via props or fetched
- remove duplicate `<StatsDisplay>` from `App.vue`

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684c6450d9608320b1b7c99ea480a02d