### PR TITLE
Fix StatsDisplay and remove duplicate call

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,8 +7,6 @@
     <StatsDisplay :stats="currentStats" />
     <StatsChart :items="items" />
 
-    <StatsDisplay />
-
     
     <!-- Show server error if any -->
     <div

--- a/src/components/StatsDisplay.vue
+++ b/src/components/StatsDisplay.vue
@@ -1,45 +1,22 @@
 <template>
   <div class="flex space-x-4 mb-6">
     <div class="bg-gray-100 p-4 rounded text-center">
-      <p class="text-sm text-gray-600">
-        Sold
-      </p>
-      <p class="text-xl font-bold">
-        {{ stats.sold }}
-      </p>
+      <p class="text-sm text-gray-600">Sold</p>
+      <p class="text-xl font-bold">{{ props.stats.sold }}</p>
     </div>
     <div class="bg-gray-100 p-4 rounded text-center">
-      <p class="text-sm text-gray-600">
-        Sold &amp; Paid
-      </p>
-      <p class="text-xl font-bold">
-        {{ stats.sold_paid }}
-      </p>
+      <p class="text-sm text-gray-600">Sold &amp; Paid</p>
+      <p class="text-xl font-bold">{{ props.stats.sold_paid }}</p>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-
 import type { Stats } from '../utils/stats';
 
-defineProps<{
-  stats: Stats
+const props = defineProps<{
+  stats: Stats;
 }>();
-
-import { ref, onMounted } from 'vue';
-import type { Stats } from '../utils/stats';
-import { fetchStats } from '../utils/stats';
-
-const stats = ref<Stats>({ sold: 0, sold_paid: 0 });
-
-onMounted(async () => {
-  const stored = await fetchStats();
-  if (stored) {
-    stats.value = stored;
-  }
-});
-
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- resolve merge artifacts in `StatsDisplay.vue`
- remove unused extra `StatsDisplay` instance in `App.vue`

## Testing
- `npm run lint` *(fails: Invalid option `--ignore-path` due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_684c649f0dc88320bd291fc80c348077