### PR TITLE
Add chart toggle and adjust grid layout

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,7 +6,19 @@
 
     <StatsDisplay :stats="currentStats" />
 
-    <StatsChart :items="items" />
+    <div class="flex justify-end mb-2">
+      <button
+        class="text-sm text-blue-500 hover:underline"
+        @click="showChart = !showChart"
+      >
+        {{ showChart ? 'Hide Chart' : 'Show Chart' }}
+      </button>
+    </div>
+
+    <StatsChart
+      v-if="showChart"
+      :items="items"
+    />
 
     
     <!-- Show server error if any -->
@@ -75,6 +87,7 @@ import { calculateStats, saveStats, type Stats } from './utils/stats';
 // Items state
 const items = ref<Item[]>([]);
 const showForm = ref(false);
+const showChart = ref(true);
 const isLoading = ref(true);
 const serverError = ref('');
 const editingItem = ref<Item | null>(null);

--- a/src/components/ItemGrid.vue
+++ b/src/components/ItemGrid.vue
@@ -8,7 +8,7 @@
   
   <div
     v-else
-    class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+    class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6"
   >
     <ItemCard
       v-for="item in items"


### PR DESCRIPTION
## Summary
- show chart toggle button in the main app
- improve ItemGrid mobile layout to use 2 columns on small screens

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*

------
https://chatgpt.com/codex/tasks/task_e_684c77d788148320917a8175970679ca