### PR TITLE
Add currency display and revenue stats

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -91,7 +91,7 @@ const showChart = ref(true);
 const isLoading = ref(true);
 const serverError = ref('');
 const editingItem = ref<Item | null>(null);
-const currentStats = ref<Stats>({ sold: 0, sold_paid: 0 });
+const currentStats = ref<Stats>({ sold: 0, sold_paid: 0, sold_paid_total: 0 });
 
 
 

--- a/src/components/EditItemForm.vue
+++ b/src/components/EditItemForm.vue
@@ -27,7 +27,7 @@
     <div class="mb-4">
       <label class="block text-gray-700 font-medium mb-2">Price</label>
       <input
-        v-model="form.price"
+        v-model="displayPrice"
         type="text"
         class="w-full px-3 py-2 border border-gray-300 rounded"
         placeholder="Enter item price"
@@ -107,7 +107,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue';
+import { ref, watch, computed } from 'vue';
 import type { Item } from '../types/item';
 import { statusOptions } from '../types/item';
 import { supabase } from '../supabaseClient';
@@ -123,6 +123,14 @@ const form = ref({
   location: props.item.location,
   price: props.item.price,
   dateAdded: props.item.dateAdded.slice(0, 10),
+});
+
+const displayPrice = computed({
+  get: () => (form.value.price ? `$${form.value.price}` : ''),
+  set: (val: string) => {
+    const numeric = val.replace(/[^0-9.]/g, '');
+    form.value.price = numeric;
+  }
 });
 
 const selectedFile = ref<File | null>(null);

--- a/src/components/ItemCard.vue
+++ b/src/components/ItemCard.vue
@@ -39,7 +39,7 @@
         {{ item.details }}
       </p>
       <p class="text-gray-600 text-sm mb-1">
-        Price: {{ item.price }}
+        Price: ${{ item.price }}
       </p>
       <p class="text-gray-600 text-sm mb-1">
         Location: {{ item.location }}

--- a/src/components/ItemForm.vue
+++ b/src/components/ItemForm.vue
@@ -27,7 +27,7 @@
     <div class="mb-4">
       <label class="block text-gray-700 font-medium mb-2">Price</label>
       <input
-        v-model="newItem.price"
+        v-model="displayPrice"
         type="text"
         class="w-full px-3 py-2 border border-gray-300 rounded"
         placeholder="Enter item price"
@@ -119,6 +119,14 @@ const newItem = ref({
   status: 'not_sold' as const,
   location: '',
   price: ''
+});
+
+const displayPrice = computed({
+  get: () => (newItem.value.price ? `$${newItem.value.price}` : ''),
+  set: (val: string) => {
+    const numeric = val.replace(/[^0-9.]/g, '');
+    newItem.value.price = numeric;
+  }
 });
 const selectedFile = ref<File | null>(null);
 const previewUrl = ref<string>('');

--- a/src/components/StatsDisplay.vue
+++ b/src/components/StatsDisplay.vue
@@ -16,6 +16,14 @@
         {{ props.stats.sold_paid }}
       </p>
     </div>
+    <div class="bg-gray-100 p-4 rounded text-center">
+      <p class="text-sm text-gray-600">
+        Paid Total
+      </p>
+      <p class="text-xl font-bold">
+        ${{ props.stats.sold_paid_total.toFixed(2) }}
+      </p>
+    </div>
   </div>
 </template>
 

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -4,6 +4,7 @@ import type { Item } from '../types/item';
 export interface Stats {
   sold: number;
   sold_paid: number;
+  sold_paid_total: number;
 }
 
 
@@ -18,8 +19,13 @@ const FILE_PATH = 'current-stats.json';
 
 export function calculateStats(items: Item[]): Stats {
   const sold = items.filter(i => i.status === 'sold').length;
-  const sold_paid = items.filter(i => i.status === 'sold_paid').length;
-  return { sold, sold_paid };
+  const soldPaidItems = items.filter(i => i.status === 'sold_paid');
+  const sold_paid = soldPaidItems.length;
+  const sold_paid_total = soldPaidItems.reduce((sum, item) => {
+    const num = parseFloat(String(item.price).replace(/[^0-9.]/g, ''));
+    return sum + (isNaN(num) ? 0 : num);
+  }, 0);
+  return { sold, sold_paid, sold_paid_total };
 }
 
 


### PR DESCRIPTION
## Summary
- show price with a `$` prefix when entering prices
- display item prices with a dollar sign
- compute total dollar amount for sold & paid items

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684cac39e1d08320b52e81884638c665