### PR TITLE
Adjust mobile grid layout

### DIFF
--- a/src/components/ItemGrid.vue
+++ b/src/components/ItemGrid.vue
@@ -8,7 +8,7 @@
   
   <div
     v-else
-    class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6"
+    class="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 gap-6"
   >
     <ItemCard
       v-for="item in items"


### PR DESCRIPTION
## Summary
- tweak ItemGrid responsive classes so mobile phones show two columns

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d80b382c4832086f979852dc917f9