### PR TITLE
Auto scroll to edit form

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -188,6 +188,8 @@ const handleItemAdded = (newItem: Item) => {
 const startEdit = (item: Item) => {
   editingItem.value = item;
   showForm.value = false;
+  // Scroll to top so the edit form is visible without manual scrolling
+  window.scrollTo({ top: 0, behavior: 'smooth' });
 };
 
 // Handle updated item from edit form


### PR DESCRIPTION
## Summary
- smoothly scroll to top when an item is selected for editing

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d825ac52c8320aa0051da5f03d864