### PR TITLE
Add item count and hide chart by default

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -87,11 +87,11 @@ import { calculateStats, saveStats, type Stats } from './utils/stats';
 // Items state
 const items = ref<Item[]>([]);
 const showForm = ref(false);
-const showChart = ref(true);
+const showChart = ref(false);
 const isLoading = ref(true);
 const serverError = ref('');
 const editingItem = ref<Item | null>(null);
-const currentStats = ref<Stats>({ sold: 0, sold_paid: 0, sold_paid_total: 0 });
+const currentStats = ref<Stats>({ items: 0, sold: 0, sold_paid: 0, sold_paid_total: 0 });
 
 
 

--- a/src/components/StatsDisplay.vue
+++ b/src/components/StatsDisplay.vue
@@ -2,6 +2,14 @@
   <div class="flex space-x-4 mb-6">
     <div class="bg-gray-100 p-4 rounded text-center">
       <p class="text-sm text-gray-600">
+        Items
+      </p>
+      <p class="text-xl font-bold">
+        {{ props.stats.items }}
+      </p>
+    </div>
+    <div class="bg-gray-100 p-4 rounded text-center">
+      <p class="text-sm text-gray-600">
         Sold
       </p>
       <p class="text-xl font-bold">


### PR DESCRIPTION
## Summary
- show total item count in StatsDisplay
- include item count in stats logic
- default the chart to be hidden on page load

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d9034ce7c8320bad89bf81b3ca513