### PR TITLE
Add paid totals to stats chart

### DIFF
--- a/src/components/StatsChart.vue
+++ b/src/components/StatsChart.vue
@@ -8,16 +8,40 @@
 import { ref, onMounted, watch } from 'vue';
 import { Chart, registerables } from 'chart.js';
 import type { Item } from '../types/item';
-import { calculatePeriodStats, type PeriodStats } from '../utils/stats';
+import {
+  calculatePeriodStats,
+  calculatePeriodTotals,
+  type PeriodStats,
+  type PeriodTotals
+} from '../utils/stats';
 
 const props = defineProps<{ items: Item[] }>();
 
 const canvas = ref<HTMLCanvasElement | null>(null);
 let chart: Chart | null = null;
 
-function buildData(items: Item[]): number[] {
-  const stats: PeriodStats = calculatePeriodStats(items);
-  return [stats.last30Days, stats.last6Months, stats.lastYear];
+interface ChartData {
+  counts: number[];
+  totals: number[];
+}
+
+function buildData(items: Item[]): ChartData {
+  const countStats: PeriodStats = calculatePeriodStats(items);
+  const totalStats: PeriodTotals = calculatePeriodTotals(items);
+
+  const counts = [
+    countStats.last30Days,
+    countStats.last6Months,
+    countStats.lastYear
+  ];
+
+  const totals = [
+    totalStats.last30Days,
+    totalStats.last6Months,
+    totalStats.lastYear
+  ];
+
+  return { counts, totals };
 }
 
 function renderChart() {
@@ -25,7 +49,8 @@ function renderChart() {
   const data = buildData(props.items);
 
   if (chart) {
-    chart.data.datasets[0].data = data;
+    chart.data.datasets[0].data = data.counts;
+    chart.data.datasets[1].data = data.totals;
     chart.update();
     return;
   }
@@ -39,7 +64,14 @@ function renderChart() {
         {
           label: 'Items Sold',
           backgroundColor: '#60a5fa',
-          data
+          yAxisID: 'yCounts',
+          data: data.counts
+        },
+        {
+          label: 'Paid Total ($)',
+          backgroundColor: '#34d399',
+          yAxisID: 'yTotals',
+          data: data.totals
         }
       ]
     },
@@ -47,9 +79,14 @@ function renderChart() {
       responsive: true,
       maintainAspectRatio: false,
       scales: {
-        y: {
+        yCounts: {
           beginAtZero: true,
+          position: 'left',
           ticks: { precision: 0 }
+        },
+        yTotals: {
+          beginAtZero: true,
+          position: 'right'
         }
       }
     }

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -15,6 +15,12 @@ export interface PeriodStats {
   lastYear: number;
 }
 
+export interface PeriodTotals {
+  last30Days: number;
+  last6Months: number;
+  lastYear: number;
+}
+
 const BUCKET = 'stats';
 const FILE_PATH = 'current-stats.json';
 
@@ -49,6 +55,32 @@ export function calculatePeriodStats(items: Item[]): PeriodStats {
     last30Days: countSince(d30),
     last6Months: countSince(m6),
     lastYear: countSince(y1)
+  };
+}
+
+export function calculatePeriodTotals(items: Item[]): PeriodTotals {
+  const now = new Date();
+  const d30 = new Date(now);
+  d30.setDate(now.getDate() - 30);
+  const m6 = new Date(now);
+  m6.setMonth(now.getMonth() - 6);
+  const y1 = new Date(now);
+  y1.setFullYear(now.getFullYear() - 1);
+
+  const totalSince = (date: Date) =>
+    items.reduce((sum, item) => {
+      if (item.status === 'sold_paid' && new Date(item.dateAdded) >= date) {
+        const num = parseFloat(String(item.price).replace(/[^0-9.]/g, ''));
+        const net = isNaN(num) ? 0 : num * 0.8;
+        return sum + net;
+      }
+      return sum;
+    }, 0);
+
+  return {
+    last30Days: totalSince(d30),
+    last6Months: totalSince(m6),
+    lastYear: totalSince(y1)
   };
 }
 


### PR DESCRIPTION
## Summary
- calculate paid totals per period
- display paid totals alongside sold counts in StatsChart

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d9275e99883209df1e566e2a1b045