### PR TITLE
Fix iOS startup theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/Uglyico.ico" />
     <link rel="manifest" href="/manifest.webmanifest" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Artwork Tracker</title>
   </head>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -3,8 +3,8 @@
   "short_name": "ItemTracker",
   "start_url": ".",
   "display": "standalone",
-  "background_color": "#ffffff",
-  "theme_color": "#ffffff",
+  "background_color": "#000000",
+  "theme_color": "#000000",
   "icons": [
     {
       "src": "/ugly_192px.png",

--- a/src/AppRoot.vue
+++ b/src/AppRoot.vue
@@ -3,7 +3,7 @@
     <router-view />
     <div
       v-if="showLanding"
-      class="fixed inset-0 flex items-center justify-center bg-gray-800 z-50"
+      class="fixed inset-0 flex items-center justify-center bg-black z-50"
     >
       <img
         src="https://ielukqallxtceqmobmvp.supabase.co/storage/v1/object/public/images//1749825362414.png"


### PR DESCRIPTION
## Summary
- tweak iOS status bar meta tags
- set dark theme in PWA manifest
- make landing overlay background black

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684da327950c83208b543f644646748f