### PR TITLE
Center intro animation

### DIFF
--- a/src/AppRoot.vue
+++ b/src/AppRoot.vue
@@ -8,7 +8,7 @@
       <img
         src="/Uglygif.gif.GIF"
         alt="Intro animation"
-        class="w-48 h-48"
+        class="w-full h-auto max-w-[640px] max-h-[854px] object-contain"
       >
     </div>
   </div>


### PR DESCRIPTION
## Summary
- show the intro GIF responsively so it stays centered on all screens

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684dbe7243a883208533dfb722adabdf