### PR TITLE
Fix initial white flash and longer intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ item-tracker-app/
 ```
 
 ## Landing Page
-When the application loads, an animation briefly appears on top of the main page. After a few seconds the animation disappears, revealing the app at the root path `/` without changing the URL.
+When the application loads, an animation briefly appears on top of the main page. After about five seconds the animation disappears, revealing the app at the root path `/` without changing the URL.
 
 ## Technology Stack
 

--- a/index.html
+++ b/index.html
@@ -9,6 +9,12 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Artwork Tracker</title>
+    <style>
+      /* Prevent white flash before the Vue app mounts */
+      body {
+        background-color: #000;
+      }
+    </style>
   </head>
   <body>
     <div id="app"></div>

--- a/src/AppRoot.vue
+++ b/src/AppRoot.vue
@@ -22,6 +22,6 @@ const showLanding = ref(true);
 onMounted(() => {
   setTimeout(() => {
     showLanding.value = false;
-  }, 3000);
+  }, 5000);
 });
 </script>


### PR DESCRIPTION
## Summary
- black loading background to avoid white flash
- show intro GIF for 5 seconds
- update readme about intro timing

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684dc0c11bd883209a9f781e2f314691