### PR TITLE
Fix overlay background reset

### DIFF
--- a/src/AppRoot.vue
+++ b/src/AppRoot.vue
@@ -23,6 +23,7 @@ const showLanding = ref(true);
 onMounted(() => {
   setTimeout(() => {
     showLanding.value = false;
+    document.body.style.backgroundColor = '#f3f4f6';
   }, 5000);
 });
 </script>


### PR DESCRIPTION
## Summary
- ensure the body background returns to the default off-white color after the landing animation finishes

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684de5542c408320af0f1e1cd6085723