### PR TITLE
Add paid status rename and layout toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ A single-page application built with Vue 3 and TypeScript for tracking items wit
 ## Features
 
 - Add items with images, names, prices, locations, and detailed descriptions
-- Track item sales status (Not Sold / Sold / Sold & Paid)
-- Simple statistics for Sold and Sold & Paid counts stored in Supabase, updated automatically when items change
-- Sold & Paid totals subtract a 20% shop fee from each sale
+- Track item sales status (Not Sold / Sold / Paid)
+- Simple statistics for Sold and Paid counts stored in Supabase, updated automatically when items change
+- Paid totals subtract a 20% shop fee from each sale
 - Bar chart showing how many items were sold in the last 30 days, 6 months, and year
 - Record when each item was added and display this date
 - View all items in a responsive grid layout

--- a/src/App.vue
+++ b/src/App.vue
@@ -54,6 +54,28 @@
       </button>
     </div>
     
+    <div class="mb-4 flex justify-end">
+      <label
+        for="layout"
+        class="mr-2 text-sm text-gray-700"
+      >Layout:</label>
+      <select
+        id="layout"
+        v-model.number="columns"
+        class="border border-gray-300 rounded px-2 py-1 text-sm"
+      >
+        <option :value="1">
+          1 column
+        </option>
+        <option :value="2">
+          2 columns
+        </option>
+        <option :value="3">
+          3 columns
+        </option>
+      </select>
+    </div>
+
     <div
       v-if="isLoading"
       class="text-center py-8"
@@ -64,6 +86,7 @@
     <ItemGrid
       v-else
       :items="items"
+      :columns="columns"
       @update-status="updateItemStatus"
       @delete-item="deleteItem"
       @edit-item="startEdit"
@@ -88,6 +111,7 @@ import { calculateStats, saveStats, type Stats } from './utils/stats';
 const items = ref<Item[]>([]);
 const showForm = ref(false);
 const showChart = ref(false);
+const columns = ref(2);
 const isLoading = ref(true);
 const serverError = ref('');
 const editingItem = ref<Item | null>(null);

--- a/src/components/ItemGrid.vue
+++ b/src/components/ItemGrid.vue
@@ -8,7 +8,8 @@
   
   <div
     v-else
-    class="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 gap-6"
+    class="grid gap-6"
+    :class="columnsClass"
   >
     <ItemCard
       v-for="item in items"
@@ -23,12 +24,26 @@
 
 <script setup lang="ts">
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import { computed } from 'vue';
 import ItemCard from './ItemCard.vue';
 import type { Item } from '../types/item';
 
-defineProps<{
+const props = defineProps<{
   items: Item[];
+  columns: number;
 }>();
+
+const columnsClass = computed(() => {
+  switch (props.columns) {
+    case 1:
+      return 'grid-cols-1';
+    case 3:
+      return 'grid-cols-3';
+    case 2:
+    default:
+      return 'grid-cols-2';
+  }
+});
 
 defineEmits<{
   'update-status': [string, 'not_sold' | 'sold' | 'sold_paid']

--- a/src/components/StatsDisplay.vue
+++ b/src/components/StatsDisplay.vue
@@ -18,7 +18,7 @@
     </div>
     <div class="bg-gray-100 p-4 rounded text-center">
       <p class="text-sm text-gray-600">
-        Sold &amp; Paid
+        Paid
       </p>
       <p class="text-xl font-bold">
         {{ props.stats.sold_paid }}

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -12,7 +12,7 @@ export interface Item {
 export const statusOptions = [
   { value: "not_sold", label: "Not Sold" },
   { value: "sold", label: "Sold" },
-  { value: "sold_paid", label: "Sold & Paid" }
+  { value: "sold_paid", label: "Paid" }
 ] as const;
 
 export function mapRecordToItem(record: any): Item {


### PR DESCRIPTION
## Summary
- rename "Sold & Paid" status to "Paid"
- allow custom grid columns via dropdown

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684edeb501dc83209606667cc184a89a