### PR TITLE
Add searchable tags

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -76,6 +76,30 @@
       </select>
     </div>
 
+    <div class="mb-4 flex items-end space-x-2">
+      <input
+        v-model="searchQuery"
+        type="text"
+        placeholder="Search"
+        class="flex-1 border border-gray-300 rounded px-2 py-1"
+      >
+      <select
+        v-model="searchTag"
+        class="border border-gray-300 rounded px-2 py-1"
+      >
+        <option value="">
+          All Tags
+        </option>
+        <option
+          v-for="tag in uniqueTags"
+          :key="tag"
+          :value="tag"
+        >
+          {{ tag }}
+        </option>
+      </select>
+    </div>
+
     <div
       v-if="isLoading"
       class="text-center py-8"
@@ -85,7 +109,7 @@
     
     <ItemGrid
       v-else
-      :items="items"
+      :items="filteredItems"
       :columns="columns"
       @update-status="updateItemStatus"
       @delete-item="deleteItem"
@@ -95,7 +119,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, watch } from 'vue';
+import { ref, onMounted, watch, computed } from 'vue';
 import ItemForm from './components/ItemForm.vue';
 import EditItemForm from './components/EditItemForm.vue';
 import ItemGrid from './components/ItemGrid.vue';
@@ -116,6 +140,28 @@ const isLoading = ref(true);
 const serverError = ref('');
 const editingItem = ref<Item | null>(null);
 const currentStats = ref<Stats>({ items: 0, sold: 0, sold_paid: 0, sold_paid_total: 0 });
+const searchQuery = ref('');
+const searchTag = ref('');
+
+const uniqueTags = computed(() => {
+  const tags = items.value.flatMap(item => item.tags || []);
+  return Array.from(new Set(tags));
+});
+
+const filteredItems = computed(() => {
+  let results = items.value;
+  if (searchQuery.value.trim()) {
+    const q = searchQuery.value.toLowerCase();
+    results = results.filter(i =>
+      i.name.toLowerCase().includes(q) ||
+      i.details.toLowerCase().includes(q)
+    );
+  }
+  if (searchTag.value) {
+    results = results.filter(i => i.tags && i.tags.includes(searchTag.value));
+  }
+  return results;
+});
 
 
 

--- a/src/components/EditItemForm.vue
+++ b/src/components/EditItemForm.vue
@@ -89,6 +89,32 @@
       </select>
     </div>
 
+    <div class="mb-4">
+      <label class="block text-gray-700 font-medium mb-2">Tags</label>
+      <div class="flex flex-wrap mb-2">
+        <span
+          v-for="(tag, idx) in form.tags"
+          :key="idx"
+          class="bg-gray-200 rounded-full px-2 py-1 text-sm mr-2 mb-2 flex items-center"
+        >
+          {{ tag }}
+          <button
+            class="ml-1 text-red-500"
+            @click="removeTag(idx)"
+          >
+            ✕
+          </button>
+        </span>
+      </div>
+      <input
+        v-model="tagInput"
+        type="text"
+        class="w-full px-3 py-2 border border-gray-300 rounded"
+        placeholder="Add tag and press Enter"
+        @keyup.enter.prevent="addTag"
+      >
+    </div>
+
     <div class="flex space-x-2">
       <button
         class="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded font-medium"
@@ -123,6 +149,7 @@ const form = ref({
   location: props.item.location,
   price: props.item.price,
   dateAdded: props.item.dateAdded.slice(0, 10),
+  tags: [...(props.item.tags || [])]
 });
 
 const displayPrice = computed({
@@ -135,6 +162,7 @@ const displayPrice = computed({
 
 const selectedFile = ref<File | null>(null);
 const previewUrl = ref<string>(props.item.imageUrl);
+const tagInput = ref('');
 
 watch(
   () => props.item,
@@ -146,6 +174,7 @@ watch(
       location: val.location,
       price: val.price,
       dateAdded: val.dateAdded.slice(0, 10),
+      tags: [...(val.tags || [])]
     };
     previewUrl.value = val.imageUrl;
     selectedFile.value = null;
@@ -158,6 +187,18 @@ function onFileChange(e: Event) {
     selectedFile.value = files[0];
     previewUrl.value = URL.createObjectURL(files[0]);
   }
+}
+
+function addTag() {
+  const val = tagInput.value.trim();
+  if (val && !form.value.tags.includes(val)) {
+    form.value.tags.push(val);
+  }
+  tagInput.value = '';
+}
+
+function removeTag(index: number) {
+  form.value.tags.splice(index, 1);
 }
 
 async function handleSubmit() {
@@ -183,6 +224,7 @@ async function handleSubmit() {
         price: form.value.price,
         image_url: imageUrl,
         date_added: new Date(form.value.dateAdded).toISOString(),
+        tags: form.value.tags
       })
       .eq('id', props.item.id)
       .select()
@@ -199,6 +241,7 @@ async function handleSubmit() {
       dateAdded: updated.date_added,
       location: updated.location,
       price: updated.price,
+      tags: updated.tags ?? []
     };
 
     emit('item-updated', item);

--- a/src/components/ItemForm.vue
+++ b/src/components/ItemForm.vue
@@ -173,7 +173,8 @@ const handleSubmit = async () => {
         location: newItem.value.location,
         price: newItem.value.price,
         image_url: imageUrl,
-        date_added: new Date().toISOString()
+        date_added: new Date().toISOString(),
+        tags: []
       }
     ])
     .select()
@@ -189,7 +190,8 @@ const handleSubmit = async () => {
     status: inserted.status,
     dateAdded: inserted.date_added,
     location: inserted.location,
-    price: inserted.price
+    price: inserted.price,
+    tags: []
   };
 
   emit('item-added', item);

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -7,6 +7,7 @@ export interface Item {
   dateAdded: string;
   location: string;
   price: string;
+  tags: string[];
 }
 
 export const statusOptions = [
@@ -24,7 +25,8 @@ export function mapRecordToItem(record: any): Item {
     status: record.status,
     dateAdded: record.date_added,
     location: record.location,
-    price: record.price
+    price: record.price,
+    tags: record.tags ?? []
 
   };
 }
@@ -41,7 +43,8 @@ export const defaultItems: Item[] = [
     status: "not_sold",
     dateAdded: new Date().toISOString(),
     location: "New York, NY",
-    price: "199.99"
+    price: "199.99",
+    tags: []
   },
   {
     id: "2",
@@ -51,7 +54,8 @@ export const defaultItems: Item[] = [
     status: "sold",
     dateAdded: new Date().toISOString(),
     location: "San Francisco, CA",
-    price: "899.99"
+    price: "899.99",
+    tags: []
   }
 ];
 


### PR DESCRIPTION
## Summary
- include `tags` field in `Item` type and default items
- support tag editing within `EditItemForm`
- store tags when creating or updating items
- add search bar with optional tag filter

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684ee100f5608320a75c090ec860a0ce