### PR TITLE
Fix tag display for search toggle

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -144,8 +144,8 @@ const searchQuery = ref('');
 const searchTag = ref('');
 
 const uniqueTags = computed(() => {
-  const tags = items.value.flatMap(item => item.tags || []);
-  return Array.from(new Set(tags));
+  const tags = items.value.flatMap(item => Array.isArray(item.tags) ? item.tags : []);
+  return Array.from(new Set(tags)).filter(tag => typeof tag === 'string' && tag.trim() !== '');
 });
 
 const filteredItems = computed(() => {

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -17,6 +17,20 @@ export const statusOptions = [
 ] as const;
 
 export function mapRecordToItem(record: any): Item {
+  let tags: string[] = [];
+  if (Array.isArray(record.tags)) {
+    tags = record.tags;
+  } else if (typeof record.tags === 'string') {
+    try {
+      const parsed = JSON.parse(record.tags);
+      if (Array.isArray(parsed)) {
+        tags = parsed;
+      }
+    } catch {
+      // leave tags as empty array
+    }
+  }
+
   return {
     id: record.id,
     name: record.name,
@@ -26,7 +40,7 @@ export function mapRecordToItem(record: any): Item {
     dateAdded: record.date_added,
     location: record.location,
     price: record.price,
-    tags: record.tags ?? []
+    tags
 
   };
 }


### PR DESCRIPTION
## Summary
- normalize `record.tags` when converting DB records so stray strings don't leak through
- filter unique tags to only allow non-empty strings

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684eeb47d52483209c7fb736c0de5f47