### PR TITLE
Display tags and simplify search

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -83,21 +83,13 @@
         placeholder="Search"
         class="flex-1 border border-gray-300 rounded px-2 py-1"
       >
-      <select
-        v-model="searchTag"
-        class="border border-gray-300 rounded px-2 py-1"
+      <button
+        v-if="searchQuery"
+        class="border border-gray-300 rounded px-2 py-1 bg-gray-100"
+        @click="clearSearch"
       >
-        <option value="">
-          All Tags
-        </option>
-        <option
-          v-for="tag in uniqueTags"
-          :key="tag"
-          :value="tag"
-        >
-          {{ tag }}
-        </option>
-      </select>
+        Clear
+      </button>
     </div>
 
     <div
@@ -141,12 +133,10 @@ const serverError = ref('');
 const editingItem = ref<Item | null>(null);
 const currentStats = ref<Stats>({ items: 0, sold: 0, sold_paid: 0, sold_paid_total: 0 });
 const searchQuery = ref('');
-const searchTag = ref('');
 
-const uniqueTags = computed(() => {
-  const tags = items.value.flatMap(item => Array.isArray(item.tags) ? item.tags : []);
-  return Array.from(new Set(tags)).filter(tag => typeof tag === 'string' && tag.trim() !== '');
-});
+function clearSearch() {
+  searchQuery.value = '';
+}
 
 const filteredItems = computed(() => {
   let results = items.value;
@@ -156,9 +146,6 @@ const filteredItems = computed(() => {
       i.name.toLowerCase().includes(q) ||
       i.details.toLowerCase().includes(q)
     );
-  }
-  if (searchTag.value) {
-    results = results.filter(i => i.tags && i.tags.includes(searchTag.value));
   }
   return results;
 });

--- a/src/components/ItemCard.vue
+++ b/src/components/ItemCard.vue
@@ -47,6 +47,18 @@
       <p class="text-gray-500 text-xs mb-3">
         Added {{ formattedDate }}
       </p>
+      <div
+        v-if="item.tags && item.tags.length"
+        class="flex flex-wrap mb-3"
+      >
+        <span
+          v-for="(tag, idx) in item.tags"
+          :key="idx"
+          class="bg-gray-200 rounded-full px-2 py-1 text-xs mr-2 mb-1"
+        >
+          {{ tag }}
+        </span>
+      </div>
       
       <!-- Status controls -->
       <div class="mb-3">


### PR DESCRIPTION
## Summary
- show item tags on `ItemCard`
- remove tag dropdown and add a Clear button for search

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ef5feca4c832088aef8b68814914a