### PR TITLE
Fix tags saved as string

### DIFF
--- a/src/components/EditItemForm.vue
+++ b/src/components/EditItemForm.vue
@@ -135,7 +135,7 @@
 <script setup lang="ts">
 import { ref, watch, computed } from 'vue';
 import type { Item } from '../types/item';
-import { statusOptions } from '../types/item';
+import { statusOptions, mapRecordToItem } from '../types/item';
 import { supabase } from '../supabaseClient';
 
 const props = defineProps<{ item: Item }>();
@@ -232,17 +232,7 @@ async function handleSubmit() {
 
     if (error) throw error;
 
-    const item: Item = {
-      id: updated.id,
-      name: updated.name,
-      imageUrl: updated.image_url ?? '',
-      details: updated.details,
-      status: updated.status,
-      dateAdded: updated.date_added,
-      location: updated.location,
-      price: updated.price,
-      tags: updated.tags ?? []
-    };
+    const item: Item = mapRecordToItem(updated);
 
     emit('item-updated', item);
   } catch (err: any) {

--- a/src/components/ItemForm.vue
+++ b/src/components/ItemForm.vue
@@ -106,6 +106,7 @@
 import { ref, computed } from 'vue';
 import { statusOptions } from '../types/item';
 import type { Item } from '../types/item';
+import { mapRecordToItem } from '../types/item';
 import { supabase } from '../supabaseClient';
 
 const emit = defineEmits<{
@@ -182,17 +183,7 @@ const handleSubmit = async () => {
 
   if (insertError) throw insertError;
 
-  const item: Item = {
-    id: inserted.id,
-    name: inserted.name,
-    imageUrl: inserted.image_url,
-    details: inserted.details,
-    status: inserted.status,
-    dateAdded: inserted.date_added,
-    location: inserted.location,
-    price: inserted.price,
-    tags: []
-  };
+  const item: Item = mapRecordToItem(inserted);
 
   emit('item-added', item);
     newItem.value = {


### PR DESCRIPTION
## Summary
- handle tags from Supabase using `mapRecordToItem`
- parse inserted/updated records when creating/editing items so tags stay arrays

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ef8a206dc83209e117d5d0fe0ff7e