### PR TITLE
Add sign up instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,10 @@ When the application loads, an animation briefly appears on top of the main page
 The application now includes basic email/password authentication powered by
 Supabase. On first load, a login form appears after the startup animation. Users
 can sign up or sign in, and the item tracker only loads once a session is
-active. Items are saved with the authenticated user's UID (stored in a
+active.
+
+To create an account, enter your email address and a password of your choice in the form and click **Sign Up**. Use the **Login** button if you already have an account.
+ Items are saved with the authenticated user's UID (stored in a
 `user_id` column) so each account only sees its own records. See
 [docs/SUPABASE_AUTH_SETUP.md](docs/SUPABASE_AUTH_SETUP.md) for details on how
 the auth integration works, how to restrict data per user, and how to update an

--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -46,6 +46,28 @@
           Sign Up
         </button>
       </div>
+      <p class="text-center text-sm text-gray-600">
+        Enter your email and a desired password, then click <strong>Sign Up</strong> to create an account. Use the Login button if you already have an account.
+      </p>
+      <div class="text-center">
+        <button
+          type="button"
+          class="text-blue-500 text-sm underline"
+          @click="toggleInstall"
+        >
+          How to Save to Desktop
+        </button>
+        <div
+          v-if="showInstall"
+          class="mt-2 text-sm text-gray-600"
+        >
+          <p>
+            You can install this web app to run it like a native application.
+            On Chrome, open the browser menu and choose <em>Install Item Tracker</em>.
+            On Safari, tap the share icon and select <em>Add to Home Screen</em>.
+          </p>
+        </div>
+      </div>
       <p
         v-if="error"
         class="text-red-500 text-sm"
@@ -70,6 +92,7 @@ const email = ref('');
 const password = ref('');
 const error = ref('');
 const message = ref('');
+const showInstall = ref(false);
 
 async function handleLogin() {
   error.value = '';
@@ -93,6 +116,10 @@ async function handleSignup() {
   } else {
     message.value = 'Check your email to verify your account.';
   }
+}
+
+function toggleInstall() {
+  showInstall.value = !showInstall.value;
 }
 </script>
 


### PR DESCRIPTION
## Summary
- explain how to sign up in README
- show message on login page explaining sign up steps
- button that reveals instructions to install web app on desktop

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68518520d2548320a1db61fb2aeeb5fe