### PR TITLE
Add feePercent for items

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ A single-page application built with Vue 3 and TypeScript for tracking items wit
 ## Features
 
 - Add items with images, names, prices, locations, and detailed descriptions
+- Set a custom shop fee percentage for each item (defaults to 20%)
 - Track item sales status (Not Sold / Sold / Paid)
 - Simple per-user statistics for Sold and Paid counts stored in Supabase, updated automatically when items change
-- Paid totals subtract a 20% shop fee from each sale
+- Paid totals subtract the shop fee percentage from each sale (default 20%, editable per item)
 - Bar chart showing how many items were sold in the last 30 days, 6 months, and year
 - Record when each item was added and display this date
 - View all items in a responsive grid layout

--- a/docs/SUPABASE_SETUP.sql
+++ b/docs/SUPABASE_SETUP.sql
@@ -11,6 +11,7 @@ create table if not exists public.items (
   status text not null default 'not_sold',
   location text,
   price numeric,
+  fee_percent numeric default 20,
   image_url text,
   date_added timestamptz default now(),
   tags text[]

--- a/src/components/EditItemForm.vue
+++ b/src/components/EditItemForm.vue
@@ -35,6 +35,17 @@
     </div>
 
     <div class="mb-4">
+      <label class="block text-gray-700 font-medium mb-2">Shop Fee %</label>
+      <input
+        v-model.number="form.feePercent"
+        type="number"
+        class="w-full px-3 py-2 border border-gray-300 rounded"
+        min="0"
+        step="0.1"
+      >
+    </div>
+
+    <div class="mb-4">
       <label class="block text-gray-700 font-medium mb-2">Date Added</label>
       <input
         v-model="form.dateAdded"
@@ -148,6 +159,7 @@ const form = ref({
   status: props.item.status,
   location: props.item.location,
   price: props.item.price,
+  feePercent: props.item.feePercent ?? 20,
   dateAdded: props.item.dateAdded.slice(0, 10),
   tags: [...(props.item.tags || [])]
 });
@@ -173,6 +185,7 @@ watch(
       status: val.status,
       location: val.location,
       price: val.price,
+      feePercent: val.feePercent ?? 20,
       dateAdded: val.dateAdded.slice(0, 10),
       tags: [...(val.tags || [])]
     };
@@ -225,6 +238,7 @@ async function handleSubmit() {
         status: form.value.status,
         location: form.value.location,
         price: form.value.price,
+        fee_percent: form.value.feePercent,
         image_url: imageUrl,
         date_added: new Date(form.value.dateAdded).toISOString(),
         tags: form.value.tags

--- a/src/components/ItemForm.vue
+++ b/src/components/ItemForm.vue
@@ -35,6 +35,17 @@
     </div>
 
     <div class="mb-4">
+      <label class="block text-gray-700 font-medium mb-2">Shop Fee %</label>
+      <input
+        v-model.number="newItem.feePercent"
+        type="number"
+        class="w-full px-3 py-2 border border-gray-300 rounded"
+        min="0"
+        step="0.1"
+      >
+    </div>
+
+    <div class="mb-4">
       <label class="block text-gray-700 font-medium mb-2">
         Image <span class="text-red-500">*</span>
       </label>
@@ -119,7 +130,8 @@ const newItem = ref({
   details: '',
   status: 'not_sold' as const,
   location: '',
-  price: ''
+  price: '',
+  feePercent: 20
 });
 
 const displayPrice = computed({
@@ -138,7 +150,8 @@ const isFormValid = computed(() => {
     newItem.value.details.trim() &&
     selectedFile.value &&
     newItem.value.location.trim() &&
-    newItem.value.price.trim()
+    newItem.value.price.trim() &&
+    newItem.value.feePercent >= 0
   );
 });
 
@@ -177,6 +190,7 @@ const handleSubmit = async () => {
         status: newItem.value.status,
         location: newItem.value.location,
         price: newItem.value.price,
+        fee_percent: newItem.value.feePercent,
         image_url: imageUrl,
         date_added: new Date().toISOString(),
         tags: []
@@ -195,7 +209,8 @@ const handleSubmit = async () => {
       details: '',
       status: 'not_sold',
       location: '',
-      price: ''
+      price: '',
+      feePercent: 20
     };
     selectedFile.value = null;
     previewUrl.value = '';

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -9,6 +9,7 @@ export interface Item {
   dateAdded: string;
   location: string;
   price: string;
+  feePercent: number;
   tags: string[];
 }
 
@@ -43,6 +44,7 @@ export function mapRecordToItem(record: any): Item {
     dateAdded: record.date_added,
     location: record.location,
     price: record.price,
+    feePercent: typeof record.fee_percent === 'number' ? record.fee_percent : 20,
     tags
 
   };
@@ -61,6 +63,7 @@ export const defaultItems: Item[] = [
     dateAdded: new Date().toISOString(),
     location: "New York, NY",
     price: "199.99",
+    feePercent: 20,
     tags: []
   },
   {
@@ -72,6 +75,7 @@ export const defaultItems: Item[] = [
     dateAdded: new Date().toISOString(),
     location: "San Francisco, CA",
     price: "899.99",
+    feePercent: 20,
     tags: []
   }
 ];

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -37,8 +37,8 @@ export function calculateStats(items: Item[]): Stats {
   const sold_paid = soldPaidItems.length;
   const sold_paid_total = soldPaidItems.reduce((sum, item) => {
     const num = parseFloat(String(item.price).replace(/[^0-9.]/g, ''));
-    // Account for the 20% fee that goes to the shop
-    const net = isNaN(num) ? 0 : num * 0.8;
+    const fee = typeof item.feePercent === 'number' ? item.feePercent : 20;
+    const net = isNaN(num) ? 0 : num * (1 - fee / 100);
     return sum + net;
   }, 0);
   return { items: total, sold, sold_paid, sold_paid_total };
@@ -77,7 +77,8 @@ export function calculatePeriodTotals(items: Item[]): PeriodTotals {
     items.reduce((sum, item) => {
       if (item.status === 'sold_paid' && new Date(item.dateAdded) >= date) {
         const num = parseFloat(String(item.price).replace(/[^0-9.]/g, ''));
-        const net = isNaN(num) ? 0 : num * 0.8;
+        const fee = typeof item.feePercent === 'number' ? item.feePercent : 20;
+        const net = isNaN(num) ? 0 : num * (1 - fee / 100);
         return sum + net;
       }
       return sum;


### PR DESCRIPTION
## Summary
- extend Item with `feePercent`
- allow editing fee percent in create/update forms
- store `fee_percent` in Supabase and docs
- compute stats using per-item fees
- clarify README about editable shop fee

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851a5fb31948320b0170fa32637cc49