### PR TITLE
Add image viewer modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A single-page application built with Vue 3 and TypeScript for tracking items wit
 - Bar chart showing how many items were sold in the last 30 days, 6 months, and year
 - Record when each item was added and display this date
 - View all items in a responsive grid layout
+- Click an item's image to open a full-screen viewer with a close button
 - Persistent data storage using localStorage
 - Fully responsive design
 - Animation overlay that displays for a few seconds on initial load before revealing the main application

--- a/src/App.vue
+++ b/src/App.vue
@@ -114,6 +114,12 @@
       @update-status="updateItemStatus"
       @delete-item="deleteItem"
       @edit-item="startEdit"
+      @view-image="openImageViewer"
+    />
+    <ImageViewer
+      v-if="selectedImage"
+      :src="selectedImage"
+      @close="selectedImage = null"
     />
   </div>
 </template>
@@ -125,6 +131,7 @@ import EditItemForm from './components/EditItemForm.vue';
 import ItemGrid from './components/ItemGrid.vue';
 import StatsDisplay from './components/StatsDisplay.vue';
 import StatsChart from './components/StatsChart.vue';
+import ImageViewer from './components/ImageViewer.vue';
 import type { Item } from './types/item';
 import { mapRecordToItem, defaultItems } from './types/item';
 import { supabase } from './supabaseClient';
@@ -141,6 +148,7 @@ const serverError = ref('');
 const editingItem = ref<Item | null>(null);
 const currentStats = ref<Stats>({ items: 0, sold: 0, sold_paid: 0, sold_paid_total: 0 });
 const searchQuery = ref('');
+const selectedImage = ref<string | null>(null);
 
 async function signOut() {
   await supabase.auth.signOut();
@@ -148,6 +156,10 @@ async function signOut() {
 
 function clearSearch() {
   searchQuery.value = '';
+}
+
+function openImageViewer(src: string) {
+  selectedImage.value = src;
 }
 
 const filteredItems = computed(() => {

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -1,0 +1,29 @@
+<template>
+  <div
+    class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-75 z-50"
+    @click.self="emit('close')"
+  >
+    <div class="relative">
+      <button
+        class="absolute top-0 right-0 m-2 text-white text-2xl"
+        @click="emit('close')"
+      >
+        &times;
+      </button>
+      <img
+        :src="src"
+        alt="Full Image"
+        class="max-h-screen max-w-screen object-contain"
+      >
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{ src: string }>();
+const emit = defineEmits<{ close: [] }>();
+</script>
+
+<style scoped>
+/* Add any viewer-specific styles if needed */
+</style>

--- a/src/components/ItemCard.vue
+++ b/src/components/ItemCard.vue
@@ -8,11 +8,12 @@
       v-if="item.imageUrl"
       class="h-48 overflow-hidden"
     >
-      <img 
+      <img
         :src="imageToDisplay"
         :alt="item.name"
-        class="w-full h-full object-cover"
+        class="w-full h-full object-cover cursor-pointer"
         @error="handleImageError"
+        @click="handleViewImage"
       >
     </div>
     <div
@@ -122,6 +123,7 @@ const emit = defineEmits<{
   'update-status': [string, 'not_sold' | 'sold' | 'sold_paid']
   'delete-item': [string]
   'edit-item': [Item]
+  'view-image': [string]
 }>()
 
 // Add image error handling
@@ -143,6 +145,10 @@ const handleDelete = () => {
 
 const handleEdit = () => {
   emit('edit-item', props.item);
+};
+
+const handleViewImage = () => {
+  emit('view-image', imageToDisplay.value);
 };
 
 const formattedDate = computed(() => {

--- a/src/components/ItemGrid.vue
+++ b/src/components/ItemGrid.vue
@@ -18,6 +18,7 @@
       @update-status="(id, status) => $emit('update-status', id, status)"
       @delete-item="(id) => $emit('delete-item', id)"
       @edit-item="(item) => $emit('edit-item', item)"
+      @view-image="(src) => $emit('view-image', src)"
     />
   </div>
 </template>
@@ -49,6 +50,7 @@ defineEmits<{
   'update-status': [string, 'not_sold' | 'sold' | 'sold_paid']
   'delete-item': [string]
   'edit-item': [Item]
+  'view-image': [string]
 }>()
 </script>
 


### PR DESCRIPTION
## Summary
- open image viewer on clicking item image
- propagate image viewer events through ItemGrid
- add full-screen ImageViewer component
- document image viewer in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851ae14576c8320ab0c22b930a10512