### PR TITLE
Add hCaptcha setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,15 @@ npm run build
 ```
 
 ## Environment Variables
-Create a `.env` file based on `.env.example` and set `VITE_SUPABASE_URL` and `VITE_SUPABASE_KEY` with your Supabase credentials.
+Create a `.env` file based on `.env.example` and set the following variables:
+
+```
+VITE_SUPABASE_URL=<your project url>
+VITE_SUPABASE_KEY=<your anon key>
+VITE_HCAPTCHA_SITEKEY=<your hCaptcha site key>
+```
+
+Add your **hCaptcha secret key** in the Supabase Dashboard under **Settings → Authentication → Bot and Abuse Protection** when enabling CAPTCHA protection.
 
 ## Project Structure
 

--- a/docs/SUPABASE_AUTH_SETUP.md
+++ b/docs/SUPABASE_AUTH_SETUP.md
@@ -17,6 +17,7 @@ This guide explains how to add login functionality and manage users with Supabas
 ```bash
 VITE_SUPABASE_URL=<your project url>
 VITE_SUPABASE_KEY=<your anon key>
+VITE_HCAPTCHA_SITEKEY=<your hCaptcha site key>
 ```
 
 ## 3. Set up the database
@@ -28,6 +29,7 @@ VITE_SUPABASE_KEY=<your anon key>
 
 1. Go to **Auth > Settings** and enable email/password sign in. Enable other providers as needed.
 2. Accounts created through your app will appear under **Auth > Users**.
+3. Under **Settings → Authentication → Bot and Abuse Protection**, toggle **Enable CAPTCHA protection**, choose **hCaptcha**, and enter your secret key.
 
 > **Note**
 > Your Supabase dashboard login is only for administering the project. Users who register in your app are separate and managed under the **Users** tab.

--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -32,6 +32,7 @@
         class="border w-full px-3 py-2 rounded"
       >
       <vue-hcaptcha
+        ref="captcha"
         :sitekey="siteKey"
         @verify="onVerify"
       />
@@ -101,6 +102,7 @@ const message = ref('');
 const showInstall = ref(false);
 const isSignup = ref(true);
 const captchaToken = ref('');
+const captcha = ref<InstanceType<typeof VueHcaptcha> | null>(null);
 const siteKey = import.meta.env.VITE_HCAPTCHA_SITEKEY;
 if (!siteKey) {
   console.warn('VITE_HCAPTCHA_SITEKEY is not set');
@@ -133,6 +135,8 @@ async function handleLogin() {
   } else {
     setReturningUserCookie();
   }
+  captcha.value?.reset();
+  captchaToken.value = '';
 }
 
 async function handleSignup() {
@@ -151,6 +155,8 @@ async function handleSignup() {
     message.value = 'Check your email to verify your account.';
     setReturningUserCookie();
   }
+  captcha.value?.reset();
+  captchaToken.value = '';
 }
 
 function toggleMode() {


### PR DESCRIPTION
## Summary
- reset hCaptcha widget after login and signup
- document hCaptcha site key and secret key configuration

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6853347ed9448320ae1ffed77db79211