### PR TITLE
Add password toggle on login

### DIFF
--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -24,13 +24,28 @@
         required
         class="border w-full px-3 py-2 rounded"
       >
-      <input
-        v-model="password"
-        type="password"
-        placeholder="Password"
-        required
-        class="border w-full px-3 py-2 rounded"
-      >
+      <div>
+        <input
+          id="hs-login-password"
+          v-model="password"
+          type="password"
+          placeholder="Password"
+          required
+          class="border w-full px-3 py-2 rounded"
+        >
+        <div class="flex items-center mt-2">
+          <input
+            id="hs-login-toggle"
+            type="checkbox"
+            data-hs-toggle-password="{&quot;target&quot;: &quot;#hs-login-password&quot;}"
+            class="shrink-0 mr-2 border-gray-200 rounded-sm text-blue-600 focus:ring-blue-500"
+          >
+          <label
+            for="hs-login-toggle"
+            class="text-sm text-gray-500"
+          >Show password</label>
+        </div>
+      </div>
       <vue-hcaptcha
         ref="captcha"
         :sitekey="siteKey"

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { createApp } from 'vue'
 import router from './router'
 import AppRoot from './AppRoot.vue'
 import * as ImageKitVue from '@imagekit/vue'  // Namespace import
+import 'preline/dist/preline'
 
 const app = createApp(AppRoot)
 


### PR DESCRIPTION
## Summary
- enable Preline JS globally
- add checkbox for toggling login password visibility

## Testing
- `npm run lint`
- `npm run build:css`

------
https://chatgpt.com/codex/tasks/task_e_68538d337fdc8320bc3f0f86c68a7406