### PR TITLE
Add Preline datepicker to edit form

### DIFF
--- a/src/components/EditItemForm.vue
+++ b/src/components/EditItemForm.vue
@@ -48,9 +48,14 @@
     <div class="mb-4">
       <label class="block text-gray-700 font-medium mb-2">Date Added</label>
       <input
-        v-model="form.dateAdded"
-        type="date"
-        class="w-full px-3 py-2 border border-gray-300 rounded"
+        id="edit-date-added"
+        class="hs-datepicker py-3 px-4 block w-full border-gray-200 rounded-lg"
+        type="text"
+        placeholder="Select day"
+        readonly
+        :value="form.dateAdded"
+        @change="form.dateAdded = ($event.target as HTMLInputElement).value"
+        data-hs-datepicker='{"selectionDatesMode":"multiple-ranged","dateMax":"2050-12-31"}'
       >
     </div>
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { createApp } from 'vue'
 import router from './router'
 import AppRoot from './AppRoot.vue'
 import * as ImageKitVue from '@imagekit/vue'  // Namespace import
-import 'preline/dist/preline'
+import 'preline'
 
 const app = createApp(AppRoot)
 


### PR DESCRIPTION
## Summary
- load Preline globally via `import 'preline'`
- swap `Date Added` field for Preline datepicker on EditItemForm
- sync selected date with `form.dateAdded`

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68538f9ee2e4832096c66f27cedc1aef