### PR TITLE
Fix Preline datepicker by installing required dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "imagekit": "^4.1.3",
                 "jspdf": "^2.5.1",
                 "preline": "^2.7.0",
+                "vanilla-calendar-pro": "^3.0.4",
                 "vue": "^3.3.4",
                 "vue-router": "^4.5.1"
             },
@@ -4706,6 +4707,16 @@
             "license": "MIT",
             "bin": {
                 "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/vanilla-calendar-pro": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/vanilla-calendar-pro/-/vanilla-calendar-pro-3.0.4.tgz",
+            "integrity": "sha512-i13aJsfovlfRGm7zkoxYh9WylkdLVJkjmfZjJms5cb5i/lbnPTBaDQ0J51joC3Q4h66sFpEUjA4bXLAr/OPZ2w==",
+            "license": "MIT",
+            "funding": {
+                "type": "individual",
+                "url": "https://buymeacoffee.com/uvarov"
             }
         },
         "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "imagekit": "^4.1.3",
         "jspdf": "^2.5.1",
         "preline": "^2.7.0",
+        "vanilla-calendar-pro": "^3.0.4",
         "vue": "^3.3.4",
         "vue-router": "^4.5.1"
     },


### PR DESCRIPTION
## Summary
- include `vanilla-calendar-pro` dependency required by Preline's datepicker

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6854037258488320853a905c69fb7b75