### PR TITLE
Replace Preline datepicker with VanillaCalendar

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -4,8 +4,6 @@
 @tailwind components;
 @tailwind utilities;
 
-@import '@preline/datepicker/styles.css';
-@import '@preline/datepicker/variants.css';
 
 body {
   @apply bg-gray-100 text-gray-800;

--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -1,0 +1,52 @@
+<template>
+  <input
+    ref="inputRef"
+    type="text"
+    :placeholder="placeholder"
+    class="w-full px-3 py-2 border border-gray-300 rounded"
+  >
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount, watch } from 'vue';
+import { Calendar } from 'vanilla-calendar-pro';
+import 'vanilla-calendar-pro/styles/layout.css';
+import 'vanilla-calendar-pro/styles/themes/light.css';
+import 'vanilla-calendar-pro/styles/themes/dark.css';
+
+const props = defineProps<{
+  modelValue: string;
+  placeholder?: string;
+}>();
+
+const emit = defineEmits<{ 'update:modelValue': [string] }>();
+
+const inputRef = ref<HTMLInputElement | null>(null);
+let calendar: Calendar | null = null;
+
+onMounted(() => {
+  if (inputRef.value) {
+    calendar = new Calendar(inputRef.value, { input: true });
+    calendar.init();
+    inputRef.value.addEventListener('change', (e: Event) => {
+      emit('update:modelValue', (e.target as HTMLInputElement).value);
+    });
+    if (props.modelValue) {
+      inputRef.value.value = props.modelValue;
+    }
+  }
+});
+
+onBeforeUnmount(() => {
+  calendar?.destroy();
+});
+
+watch(
+  () => props.modelValue,
+  (val) => {
+    if (inputRef.value && inputRef.value.value !== val) {
+      inputRef.value.value = val;
+    }
+  }
+);
+</script>

--- a/src/components/EditItemForm.vue
+++ b/src/components/EditItemForm.vue
@@ -47,15 +47,10 @@
 
     <div class="mb-4">
       <label class="block text-gray-700 font-medium mb-2">Date Added</label>
-      <input
-        id="edit-date-added"
-        class="hs-datepicker py-3 px-4 block w-full border-gray-200 rounded-lg sm:text-sm focus:border-blue-600 focus:ring-blue-600 disabled:opacity-50 disabled:pointer-events-none dark:bg-neutral-900 dark:border-neutral-700 dark:text-neutral-400 dark:placeholder:text-neutral-400 dark:focus:border-blue-500 dark:focus:ring-neutral-500"
-        type="text"
+      <DatePicker
+        v-model="form.dateAdded"
         placeholder="Select day"
-        :value="form.dateAdded"
-        @change="form.dateAdded = ($event.target as HTMLInputElement).value"
-        data-hs-datepicker='{"selectionDatesMode": "multiple-ranged", "dateMax": "2050-12-31", "templates": { "arrowPrev": "<button data-vc-arrow=\"prev\" /><svg class=\"shrink-0 size-4\" xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"m15 18-6-6 6-6\"></path></svg></button>", "arrowNext": "<button data-vc-arrow=\"next\"><svg class=\"shrink-0 size-4\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"m9 18 6-6-6-6\"></path></svg></button>" }}'
-      >
+      />
     </div>
 
     <div class="mb-4">
@@ -148,10 +143,11 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, computed, onMounted } from 'vue';
+import { ref, watch, computed } from 'vue';
 import type { Item } from '../types/item';
 import { statusOptions, mapRecordToItem } from '../types/item';
 import { supabase } from '../supabaseClient';
+import DatePicker from "./DatePicker.vue";
 
 const props = defineProps<{ item: Item }>();
 
@@ -180,11 +176,6 @@ const selectedFile = ref<File | null>(null);
 const previewUrl = ref<string>(props.item.imageUrl);
 const tagInput = ref('');
 
-onMounted(() => {
-  // Initialize Preline components like datepicker
-  // when the form is displayed
-  (window as any).HSStaticMethods?.autoInit();
-});
 
 watch(
   () => props.item,
@@ -201,8 +192,6 @@ watch(
     };
     previewUrl.value = val.imageUrl;
     selectedFile.value = null;
-    // Re-init datepicker when switching items
-    (window as any).HSStaticMethods?.autoInit();
   }
 );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,6 @@ import router from './router'
 import AppRoot from './AppRoot.vue'
 import * as ImageKitVue from '@imagekit/vue'  // Namespace import
 import 'preline'
-import '@preline/datepicker'
 
 const app = createApp(AppRoot)
 


### PR DESCRIPTION
## Summary
- remove Preline datepicker styles and plugin
- add a VanillaCalendar-based `DatePicker` component
- use the new component in `EditItemForm`

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6854063203f08320a5a9662c952ca3e3