### PR TITLE
Use native date picker in edit form

### DIFF
--- a/src/components/EditItemForm.vue
+++ b/src/components/EditItemForm.vue
@@ -47,10 +47,11 @@
 
     <div class="mb-4">
       <label class="block text-gray-700 font-medium mb-2">Date Added</label>
-      <DatePicker
+      <input
         v-model="form.dateAdded"
-        placeholder="Select day"
-      />
+        type="date"
+        class="w-full px-3 py-2 border border-gray-300 rounded"
+      >
     </div>
 
     <div class="mb-4">
@@ -147,7 +148,6 @@ import { ref, watch, computed } from 'vue';
 import type { Item } from '../types/item';
 import { statusOptions, mapRecordToItem } from '../types/item';
 import { supabase } from '../supabaseClient';
-import DatePicker from "./DatePicker.vue";
 
 const props = defineProps<{ item: Item }>();
 


### PR DESCRIPTION
## Summary
- implement `type="date"` input for editing an item's **Date Added**

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68540f017d408320b35bf00de840d4b6