### PR TITLE
Add Preline datepicker styles

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -4,6 +4,9 @@
 @tailwind components;
 @tailwind utilities;
 
+@import "@preline/datepicker/variants.css";
+@import "@preline/datepicker/styles.css";
+
 
 body {
   @apply bg-gray-100 text-gray-800;


### PR DESCRIPTION
## Summary
- import Preline datepicker CSS in `main.css`

## Testing
- `npm run build:css`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68541adbc1e48320ad7c5629bdb926f5