### PR TITLE
Fix preline import path

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import router from './router'
 import AppRoot from './AppRoot.vue'
 import * as ImageKitVue from '@imagekit/vue'  // Namespace import
 import 'vanillajs-datepicker/css/datepicker.min.css'
-import 'preline/preline'
+import 'preline/dist/preline.js'
 // import { Datepicker } from 'preline' // Optional: manual init
 
 const app = createApp(AppRoot)


### PR DESCRIPTION
## Summary
- ensure preline imported from the built file

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68541ae1c5348320afa25926afcf7d30