### PR TITLE
Fix build error with vanillajs-datepicker CSS

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,5 +12,10 @@ export default defineConfig({
   },
   css: {
     postcss: './postcss.config.js', // If you have PostCSS config
-  }
+  },
+  build: {
+    rollupOptions: {
+      external: ['vanillajs-datepicker/css/datepicker.min.css'],
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- configure Vite rollup options to externalize the datepicker CSS

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68541ffbaf8c832085ca2ebc1204e467