### PR TITLE
Fix datepicker change event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
                 "chart.js": "^4.4.1",
                 "imagekit": "^4.1.3",
                 "jspdf": "^2.5.1",
+                "lodash": "^4.17.21",
                 "preline": "^2.7.0",
                 "vanilla-calendar-pro": "^3.0.4",
                 "vanillajs-datepicker": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "chart.js": "^4.4.1",
         "imagekit": "^4.1.3",
         "jspdf": "^2.5.1",
+        "lodash": "^4.17.21",
         "preline": "^2.7.0",
         "vanilla-calendar-pro": "^3.0.4",
         "vanillajs-datepicker": "^1.3.4",

--- a/src/components/EditItemForm.vue
+++ b/src/components/EditItemForm.vue
@@ -192,13 +192,13 @@ const datepickerData = JSON.stringify({
 });
 
 onMounted(() => {
-  if (datepickerRef.value) {
-    new HSDatepicker(datepickerRef.value);
-    datepickerRef.value.addEventListener('change', (e: Event) => {
-      form.value.dateAdded = (e.target as HTMLInputElement).value;
-    });
-    datepickerRef.value.value = form.value.dateAdded;
-  }
+    if (datepickerRef.value) {
+      new HSDatepicker(datepickerRef.value);
+      datepickerRef.value.addEventListener('change.hs.datepicker', (e: Event) => {
+        form.value.dateAdded = (e.target as HTMLInputElement).value;
+      });
+      datepickerRef.value.value = form.value.dateAdded;
+    }
 });
 
 


### PR DESCRIPTION
## Summary
- listen for `change.hs.datepicker` events from Preline datepicker

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68542650e3a48320b89ac88fd7164798