### PR TITLE
Fix calendar not loading in item section

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import AppRoot from './AppRoot.vue'
 import * as ImageKitVue from '@imagekit/vue'  // Namespace import
 import 'vanillajs-datepicker/css/datepicker.min.css'
 import 'preline/dist/preline.js'
+import '@preline/datepicker'
 // import { Datepicker } from 'preline' // Optional: manual init
 
 const app = createApp(AppRoot)


### PR DESCRIPTION
## Summary
- load the Preline datepicker plugin in the main entry

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685438a785d483208aa98a9ca10f257a