### PR TITLE
Fix Preline datepicker init

### DIFF
--- a/src/components/PrelineDatepicker.vue
+++ b/src/components/PrelineDatepicker.vue
@@ -11,7 +11,7 @@
 
 <script setup>
 import { onMounted, ref } from 'vue'
-import { Datepicker as VCalendar } from 'vanillajs-datepicker'
+import HSDatepicker from '@preline/datepicker'
 
 const datepicker = ref(null)
 
@@ -28,11 +28,8 @@ const config = JSON.stringify({
 })
 
 onMounted(() => {
-  if (window.hs?.Datepicker) {
-    window.hs.Datepicker.autoInit()
-  } else {
-    // Fallback if Preline doesn't load
-    new VCalendar(datepicker.value)
+  if (datepicker.value) {
+    new HSDatepicker(datepicker.value)
   }
 })
 </script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,6 @@ import { createApp } from 'vue'
 import router from './router'
 import AppRoot from './AppRoot.vue'
 import * as ImageKitVue from '@imagekit/vue'  // Namespace import
-import 'vanillajs-datepicker/css/datepicker.min.css'
 import 'preline/dist/preline.js'
 import '@preline/datepicker'
 // import { Datepicker } from 'preline' // Optional: manual init


### PR DESCRIPTION
## Summary
- load Preline datepicker plugin without fallback
- drop extra vanillajs CSS so Preline styles apply correctly

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68543bd89d4c8320a9eb8f0a21bf15a1