### PR TITLE
Fix Preline datepicker init

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,8 @@
                 "eslint": "^8.44.0",
                 "eslint-plugin-vue": "^9.15.1",
                 "postcss": "^8.4.25",
+                "postcss-cli": "^11.0.1",
+                "postcss-import": "^16.1.1",
                 "tailwindcss": "^3.3.2",
                 "typescript": "~5.1.6",
                 "vite": "^6.3.5",
@@ -2139,6 +2141,61 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/cliui/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/cliui/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2283,6 +2340,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "node_modules/dependency-graph": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-1.0.0.tgz",
+            "integrity": "sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/didyoumean": {
@@ -2853,6 +2920,21 @@
                 "url": "https://github.com/sponsors/rawify"
             }
         },
+        "node_modules/fs-extra": {
+            "version": "11.3.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+            "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.14"
+            }
+        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2882,6 +2964,16 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
             }
         },
         "node_modules/get-intrinsic": {
@@ -2983,6 +3075,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/graphemer": {
             "version": "1.4.0",
@@ -3291,6 +3390,19 @@
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
         },
         "node_modules/jspdf": {
             "version": "2.5.1",
@@ -3802,10 +3914,79 @@
                 "node": "^10 || ^12 || >=14"
             }
         },
+        "node_modules/postcss-cli": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-cli/-/postcss-cli-11.0.1.tgz",
+            "integrity": "sha512-0UnkNPSayHKRe/tc2YGW6XnSqqOA9eqpiRMgRlV1S6HdGi16vwJBx7lviARzbV1HpQHqLLRH3o8vTcB0cLc+5g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chokidar": "^3.3.0",
+                "dependency-graph": "^1.0.0",
+                "fs-extra": "^11.0.0",
+                "picocolors": "^1.0.0",
+                "postcss-load-config": "^5.0.0",
+                "postcss-reporter": "^7.0.0",
+                "pretty-hrtime": "^1.0.3",
+                "read-cache": "^1.0.0",
+                "slash": "^5.0.0",
+                "tinyglobby": "^0.2.12",
+                "yargs": "^17.0.0"
+            },
+            "bin": {
+                "postcss": "index.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "postcss": "^8.0.0"
+            }
+        },
+        "node_modules/postcss-cli/node_modules/postcss-load-config": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-5.1.0.tgz",
+            "integrity": "sha512-G5AJ+IX0aD0dygOE0yFZQ/huFFMSNneyfp0e3/bT05a8OfPC5FUoZRPfGijUdGOJNMewJiwzcHJXFafFzeKFVA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "lilconfig": "^3.1.1",
+                "yaml": "^2.4.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "jiti": ">=1.21.0",
+                "postcss": ">=8.0.9",
+                "tsx": "^4.8.1"
+            },
+            "peerDependenciesMeta": {
+                "jiti": {
+                    "optional": true
+                },
+                "postcss": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/postcss-import": {
-            "version": "15.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
-            "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+            "version": "16.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.1.1.tgz",
+            "integrity": "sha512-2xVS1NCZAfjtVdvXiyegxzJ447GyqCeEI5V7ApgQVOWnros1p5lGNovJNapwPpMombyFBfqDwt7AD3n2l0KOfQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3814,7 +3995,7 @@
                 "resolve": "^1.1.7"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
             },
             "peerDependencies": {
                 "postcss": "^8.0.0"
@@ -3902,6 +4083,33 @@
                 "postcss": "^8.2.14"
             }
         },
+        "node_modules/postcss-reporter": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-7.1.0.tgz",
+            "integrity": "sha512-/eoEylGWyy6/DOiMP5lmFRdmDKThqgn7D6hP2dXKJI/0rJSO1ADFNngZfDzxL0YAxFvws+Rtpuji1YIHj4mySA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "picocolors": "^1.0.0",
+                "thenby": "^1.3.4"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "postcss": "^8.1.0"
+            }
+        },
         "node_modules/postcss-selector-parser": {
             "version": "6.1.2",
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
@@ -3940,6 +4148,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/pretty-hrtime": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+            "integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/punycode": {
@@ -4012,6 +4230,16 @@
             "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
             "license": "MIT",
             "optional": true
+        },
+        "node_modules/require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/resolve": {
             "version": "1.22.10",
@@ -4193,6 +4421,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/slash": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+            "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/source-map-js": {
@@ -4468,6 +4709,24 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/tailwindcss/node_modules/postcss-import": {
+            "version": "15.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+            "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-value-parser": "^4.0.0",
+                "read-cache": "^1.0.0",
+                "resolve": "^1.1.7"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.0.0"
+            }
+        },
         "node_modules/text-segmentation": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
@@ -4484,6 +4743,13 @@
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/thenby": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/thenby/-/thenby-1.3.4.tgz",
+            "integrity": "sha512-89Gi5raiWA3QZ4b2ePcEwswC3me9JIg+ToSgtE0JWeCynLnLxNr/f9G+xfo9K+Oj4AFdom8YNJjibIARTJmapQ==",
+            "dev": true,
+            "license": "Apache-2.0"
         },
         "node_modules/thenify": {
             "version": "3.3.1",
@@ -4643,6 +4909,16 @@
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
             "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
             "license": "MIT"
+        },
+        "node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
         },
         "node_modules/update-browserslist-db": {
             "version": "1.1.3",
@@ -5096,6 +5372,16 @@
                 "node": ">=12"
             }
         },
+        "node_modules/y18n": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/yaml": {
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
@@ -5107,6 +5393,57 @@
             },
             "engines": {
                 "node": ">= 14.6"
+            }
+        },
+        "node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/yargs-parser": {
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/yargs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/yargs/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "scripts": {
         "dev": "vite",
-        "build:css": "tailwindcss -c tailwind.config.js -i ./src/assets/main.css -o ./public/main.css",
+        "build:css": "postcss ./src/assets/main.css -o ./public/main.css",
         "build": "npm run build:css && vite build",
         "preview": "vite preview",
         "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix"
@@ -34,6 +34,8 @@
         "eslint": "^8.44.0",
         "eslint-plugin-vue": "^9.15.1",
         "postcss": "^8.4.25",
+        "postcss-cli": "^11.0.1",
+        "postcss-import": "^16.1.1",
         "tailwindcss": "^3.3.2",
         "typescript": "~5.1.6",
         "vite": "^6.3.5",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,7 @@
+import postcssImport from 'postcss-import'
+import tailwindcss from 'tailwindcss'
+import autoprefixer from 'autoprefixer'
+
 export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
+  plugins: [postcssImport, tailwindcss, autoprefixer],
 }

--- a/public/main.css
+++ b/public/main.css
@@ -1,5 +1,808 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
 
+@custom-variant hs-vc-date-today {
+  &[data-vc-date-today] {
+    @slot;
+  }
+}
+
+@custom-variant hs-vc-date-hover {
+  &[data-vc-date-hover] {
+    @slot;
+  }
+}
+
+@custom-variant hs-vc-date-hover-first {
+
+  &[data-vc-date-hover='first'] {
+    @slot;
+  }
+
+  [data-vc-date-hover='first'] & {
+    @slot;
+  }
+}
+
+@custom-variant hs-vc-date-hover-last {
+
+  &[data-vc-date-hover='last'] {
+    @slot;
+  }
+
+  [data-vc-date-hover='last'] & {
+    @slot;
+  }
+}
+
+@custom-variant hs-vc-date-selected {
+  &[data-vc-date-selected] {
+    @slot;
+  }
+}
+
+@custom-variant hs-vc-calendar-selected-middle {
+
+  &[data-vc-date-selected='middle'] {
+    @slot;
+  }
+
+  [data-vc-date-selected='middle'] & {
+    @slot;
+  }
+}
+
+@custom-variant hs-vc-calendar-selected-first {
+
+  &[data-vc-date-selected='first'] {
+    @slot;
+  }
+
+  [data-vc-date-selected='first'] & {
+    @slot;
+  }
+}
+
+@custom-variant hs-vc-calendar-selected-last {
+
+  &[data-vc-date-selected='last'] {
+    @slot;
+  }
+
+  [data-vc-date-selected='last'] & {
+    @slot;
+  }
+}
+
+@custom-variant hs-vc-date-weekend {
+  &[data-vc-date-weekend] {
+    @slot;
+  }
+}
+
+@custom-variant hs-vc-week-day-off {
+  &[data-vc-week-day-off] {
+    @slot;
+  }
+}
+
+@custom-variant hs-vc-date-month-prev {
+  &[data-vc-date-month='prev'] {
+    @slot;
+  }
+}
+
+@custom-variant hs-vc-date-month-next {
+  &[data-vc-date-month='next'] {
+    @slot;
+  }
+}
+
+@custom-variant hs-vc-calendar-hidden {
+
+  &[data-vc-calendar-hidden] {
+    @slot;
+  }
+
+  [data-vc-calendar-hidden] & {
+    @slot;
+  }
+}
+
+@custom-variant hs-vc-months-month-selected {
+  &[data-vc-months-month-selected] {
+    @slot;
+  }
+}
+
+@custom-variant hs-vc-years-year-selected {
+  &[data-vc-years-year-selected] {
+    @slot;
+  }
+}
+
+.vc{
+  border-radius: 0.75rem;
+  border-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(229 231 235 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
+  --tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+@media (prefers-color-scheme: dark){
+
+  .vc{
+    --tw-border-opacity: 1;
+    border-color: rgb(64 64 64 / var(--tw-border-opacity, 1));
+    --tw-bg-opacity: 1;
+    background-color: rgb(23 23 23 / var(--tw-bg-opacity, 1));
+  }
+}
+
+.vc {
+
+  &[data-vc-input]{
+    position: absolute;
+  }
+
+  &[data-vc-type="default"]{
+    padding: 0.75rem;
+  }
+
+  &[data-vc-type="multiple"]{
+    width: 20rem;
+  }
+
+  &[data-vc-type="multiple"]{
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
+
+  @media (min-width: 640px){
+
+    &[data-vc-type="multiple"]{
+      width: 40rem;
+    }
+  }
+
+  &[data-vc-calendar-hidden]{
+    display: none;
+  }
+}
+
+.vc-week{
+  display: flex;
+  padding-bottom: 0.375rem;
+}
+
+.vc-week__day{
+  margin: 1px;
+  display: block;
+  width: 2.5rem;
+  text-align: center;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 400;
+  --tw-text-opacity: 1;
+  color: rgb(107 114 128 / var(--tw-text-opacity, 1));
+}
+
+@media (prefers-color-scheme: dark){
+
+  .vc-week__day{
+    --tw-text-opacity: 1;
+    color: rgb(115 115 115 / var(--tw-text-opacity, 1));
+  }
+}
+
+.vc-week__day {
+
+  &:focus{
+    outline: 0;
+  }
+}
+
+.vc-dates{
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  row-gap: 0.125rem;
+}
+
+.vc-date{
+  position: relative;
+  display: flex;
+  width: 2.625rem;
+  height: 2.625rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  --tw-text-opacity: 1;
+  color: rgb(31 41 55 / var(--tw-text-opacity, 1));
+}
+
+@media (prefers-color-scheme: dark){
+
+  .vc-date{
+    --tw-text-opacity: 1;
+    color: rgb(229 229 229 / var(--tw-text-opacity, 1));
+  }
+}
+
+.vc-date {
+
+  &:empty{
+    visibility: hidden;
+  }
+
+  &:hover{
+    --tw-text-opacity: 1;
+    color: rgb(37 99 235 / var(--tw-text-opacity, 1));
+  }
+
+  &:hover {
+
+    &::before{
+      --tw-border-opacity: 1;
+      border-color: rgb(37 99 235 / var(--tw-border-opacity, 1));
+    }
+  }
+
+  &:nth-child(7n){
+    border-top-right-radius: 9999px;
+    border-bottom-right-radius: 9999px;
+  }
+
+  &:nth-child(7n+1){
+    border-top-left-radius: 9999px;
+    border-bottom-left-radius: 9999px;
+  }
+
+  &::before {
+    content: "";
+  }
+
+  &::before{
+    position: absolute;
+  }
+
+  &::before{
+    inset: 0px;
+  }
+
+  &::before{
+    width: 100%;
+    height: 100%;
+  }
+
+  &::before{
+    border-radius: 9999px;
+  }
+
+  &::before{
+    border-width: 1.5px;
+  }
+
+  &::before{
+    border-color: transparent;
+  }
+
+  button{
+    position: relative;
+  }
+
+  button{
+    width: 100%;
+    height: 100%;
+  }
+
+  button{
+    border-radius: 9999px;
+  }
+
+  &[data-vc-date-month="prev"],
+  &[data-vc-date-month="next"]{
+    --tw-text-opacity: 1;
+    color: rgb(156 163 175 / var(--tw-text-opacity, 1));
+  }
+
+  @media (prefers-color-scheme: dark){
+
+    &[data-vc-date-month="prev"],
+  &[data-vc-date-month="next"]{
+      --tw-text-opacity: 1;
+      color: rgb(82 82 82 / var(--tw-text-opacity, 1));
+    }
+  }
+
+  &[data-vc-date-today]{
+    --tw-bg-opacity: 1;
+    background-color: rgb(37 99 235 / var(--tw-bg-opacity, 1));
+  }
+
+  &[data-vc-date-today]{
+    --tw-text-opacity: 1;
+    color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+  }
+
+  &[data-vc-date-selected]{
+    --tw-bg-opacity: 1;
+    background-color: rgb(37 99 235 / var(--tw-bg-opacity, 1));
+  }
+
+  &[data-vc-date-selected] {
+
+    &:not([data-vc-date-selected="middle"]){
+      --tw-text-opacity: 1;
+      color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+    }
+
+    &[data-vc-date-hover="first-and-last"]{
+      border-radius: 9999px;
+    }
+  }
+
+  &[data-vc-date-hover="first"],
+  &[data-vc-date-selected="first"]{
+    border-top-left-radius: 9999px;
+    border-bottom-left-radius: 9999px;
+  }
+
+  &[data-vc-date-hover="first"],
+  &[data-vc-date-selected="first"]{
+    border-top-right-radius: 0px;
+    border-bottom-right-radius: 0px;
+  }
+
+  &[data-vc-date-hover="first"],
+  &[data-vc-date-selected="first"] {
+
+    &::before{
+      border-top-left-radius: 9999px;
+      border-bottom-left-radius: 9999px;
+    }
+
+    &::before{
+      border-top-right-radius: 0px;
+      border-bottom-right-radius: 0px;
+    }
+  }
+
+  &[data-vc-date-hover="last"],
+  &[data-vc-date-selected="last"]{
+    border-top-right-radius: 9999px;
+    border-bottom-right-radius: 9999px;
+  }
+
+  &[data-vc-date-hover="last"],
+  &[data-vc-date-selected="last"]{
+    border-top-left-radius: 0px;
+    border-bottom-left-radius: 0px;
+  }
+
+  &[data-vc-date-hover="last"],
+  &[data-vc-date-selected="last"] {
+
+    &::before{
+      border-top-right-radius: 9999px;
+      border-bottom-right-radius: 9999px;
+    }
+
+    &::before{
+      border-top-left-radius: 0px;
+      border-bottom-left-radius: 0px;
+    }
+  }
+
+  &[data-vc-date-hover="first"][data-vc-date-selected],
+  &[data-vc-date-hover="last"][data-vc-date-selected],
+  &[data-vc-date-selected="first"],
+  &[data-vc-date-selected="last"]{
+    --tw-text-opacity: 1;
+    color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+  }
+
+  &[data-vc-date-hover="first"][data-vc-date-selected],
+  &[data-vc-date-hover="last"][data-vc-date-selected],
+  &[data-vc-date-selected="first"],
+  &[data-vc-date-selected="last"] {
+
+    &::before{
+      --tw-bg-opacity: 1;
+      background-color: rgb(37 99 235 / var(--tw-bg-opacity, 1));
+    }
+  }
+
+  &[data-vc-date-hover],
+  &[data-vc-date-selected="middle"] {
+    &:not([data-vc-date-hover="first"]):not([data-vc-date-hover="last"]):not([data-vc-date-hover="first-and-last"]){
+      border-radius: 0px;
+    }
+
+    &:not([data-vc-date-today]):not([data-vc-date-hover="first-and-last"]){
+      --tw-bg-opacity: 1;
+      background-color: rgb(243 244 246 / var(--tw-bg-opacity, 1));
+    }
+
+    @media (prefers-color-scheme: dark){
+
+      &:not([data-vc-date-today]):not([data-vc-date-hover="first-and-last"]){
+        --tw-bg-opacity: 1;
+        background-color: rgb(38 38 38 / var(--tw-bg-opacity, 1));
+      }
+    }
+  }
+}
+
+.vc-months{
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.vc-months__month{
+  display: inline-flex;
+  align-items: center;
+  -moz-column-gap: 0.5rem;
+       column-gap: 0.5rem;
+  border-radius: 0.5rem;
+  border-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(229 231 235 / var(--tw-border-opacity, 1));
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 500;
+  --tw-text-opacity: 1;
+  color: rgb(31 41 55 / var(--tw-text-opacity, 1));
+}
+
+@media (prefers-color-scheme: dark){
+
+  .vc-months__month{
+    --tw-border-opacity: 1;
+    border-color: rgb(64 64 64 / var(--tw-border-opacity, 1));
+    --tw-text-opacity: 1;
+    color: rgb(229 229 229 / var(--tw-text-opacity, 1));
+  }
+}
+
+.vc-months__month {
+
+  &:hover{
+    --tw-border-opacity: 1;
+    border-color: rgb(209 213 219 / var(--tw-border-opacity, 1));
+  }
+
+  &:hover{
+    --tw-text-opacity: 1;
+    color: rgb(107 114 128 / var(--tw-text-opacity, 1));
+  }
+
+  @media (prefers-color-scheme: dark){
+
+    &:hover{
+      --tw-border-opacity: 1;
+      border-color: rgb(82 82 82 / var(--tw-border-opacity, 1));
+    }
+  }
+
+  @media (prefers-color-scheme: dark){
+
+    &:hover{
+      --tw-text-opacity: 1;
+      color: rgb(115 115 115 / var(--tw-text-opacity, 1));
+    }
+  }
+
+  &:focus{
+    --tw-border-opacity: 1;
+    border-color: rgb(209 213 219 / var(--tw-border-opacity, 1));
+  }
+
+  &:focus{
+    --tw-text-opacity: 1;
+    color: rgb(107 114 128 / var(--tw-text-opacity, 1));
+  }
+
+  &:focus{
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+  }
+
+  @media (prefers-color-scheme: dark){
+
+    &:focus{
+      --tw-border-opacity: 1;
+      border-color: rgb(82 82 82 / var(--tw-border-opacity, 1));
+    }
+  }
+
+  @media (prefers-color-scheme: dark){
+
+    &:focus{
+      --tw-text-opacity: 1;
+      color: rgb(115 115 115 / var(--tw-text-opacity, 1));
+    }
+  }
+
+  &:disabled,
+  &.disabled{
+    pointer-events: none;
+  }
+
+  &:disabled,
+  &.disabled{
+    opacity: 0.5;
+  }
+
+  &[data-vc-months-month-selected]{
+    --tw-border-opacity: 1;
+    border-color: rgb(37 99 235 / var(--tw-border-opacity, 1));
+  }
+
+  &[data-vc-months-month-selected]{
+    --tw-bg-opacity: 1;
+    background-color: rgb(37 99 235 / var(--tw-bg-opacity, 1));
+  }
+
+  &[data-vc-months-month-selected]{
+    --tw-text-opacity: 1;
+    color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+  }
+
+  @media (prefers-color-scheme: dark){
+
+    &[data-vc-months-month-selected]{
+      --tw-border-opacity: 1;
+      border-color: rgb(59 130 246 / var(--tw-border-opacity, 1));
+    }
+  }
+
+  @media (prefers-color-scheme: dark){
+
+    &[data-vc-months-month-selected]{
+      --tw-bg-opacity: 1;
+      background-color: rgb(59 130 246 / var(--tw-bg-opacity, 1));
+    }
+  }
+}
+
+.vc-month{
+  --tw-text-opacity: 1;
+  color: rgb(31 41 55 / var(--tw-text-opacity, 1));
+}
+
+@media (prefers-color-scheme: dark){
+
+  .vc-month{
+    --tw-text-opacity: 1;
+    color: rgb(229 229 229 / var(--tw-text-opacity, 1));
+  }
+}
+
+.vc-month {
+
+  &:hover,
+  &:focus{
+    --tw-text-opacity: 1;
+    color: rgb(75 85 99 / var(--tw-text-opacity, 1));
+  }
+
+  @media (prefers-color-scheme: dark){
+
+    &:hover,
+  &:focus{
+      --tw-text-opacity: 1;
+      color: rgb(212 212 212 / var(--tw-text-opacity, 1));
+    }
+  }
+}
+
+.vc-years{
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.vc-years__year{
+  display: inline-flex;
+  align-items: center;
+  -moz-column-gap: 0.5rem;
+       column-gap: 0.5rem;
+  border-radius: 0.5rem;
+  border-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(229 231 235 / var(--tw-border-opacity, 1));
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 500;
+  --tw-text-opacity: 1;
+  color: rgb(31 41 55 / var(--tw-text-opacity, 1));
+}
+
+@media (prefers-color-scheme: dark){
+
+  .vc-years__year{
+    --tw-border-opacity: 1;
+    border-color: rgb(64 64 64 / var(--tw-border-opacity, 1));
+    --tw-text-opacity: 1;
+    color: rgb(229 229 229 / var(--tw-text-opacity, 1));
+  }
+}
+
+.vc-years__year {
+
+  &:hover,
+  &:focus{
+    --tw-border-opacity: 1;
+    border-color: rgb(209 213 219 / var(--tw-border-opacity, 1));
+  }
+
+  &:hover,
+  &:focus{
+    --tw-text-opacity: 1;
+    color: rgb(107 114 128 / var(--tw-text-opacity, 1));
+  }
+
+  @media (prefers-color-scheme: dark){
+
+    &:hover,
+  &:focus{
+      --tw-border-opacity: 1;
+      border-color: rgb(82 82 82 / var(--tw-border-opacity, 1));
+    }
+  }
+
+  @media (prefers-color-scheme: dark){
+
+    &:hover,
+  &:focus{
+      --tw-text-opacity: 1;
+      color: rgb(115 115 115 / var(--tw-text-opacity, 1));
+    }
+  }
+
+  &:focus{
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+  }
+
+  &:disabled,
+  &.disabled{
+    pointer-events: none;
+  }
+
+  &:disabled,
+  &.disabled{
+    opacity: 0.5;
+  }
+
+  &[data-vc-years-year-selected]{
+    --tw-border-opacity: 1;
+    border-color: rgb(37 99 235 / var(--tw-border-opacity, 1));
+  }
+
+  &[data-vc-years-year-selected]{
+    --tw-bg-opacity: 1;
+    background-color: rgb(37 99 235 / var(--tw-bg-opacity, 1));
+  }
+
+  &[data-vc-years-year-selected]{
+    --tw-text-opacity: 1;
+    color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+  }
+
+  @media (prefers-color-scheme: dark){
+
+    &[data-vc-years-year-selected]{
+      --tw-border-opacity: 1;
+      border-color: rgb(59 130 246 / var(--tw-border-opacity, 1));
+    }
+  }
+
+  @media (prefers-color-scheme: dark){
+
+    &[data-vc-years-year-selected]{
+      --tw-bg-opacity: 1;
+      background-color: rgb(59 130 246 / var(--tw-bg-opacity, 1));
+    }
+  }
+}
+
+.vc-year{
+  --tw-text-opacity: 1;
+  color: rgb(31 41 55 / var(--tw-text-opacity, 1));
+}
+
+@media (prefers-color-scheme: dark){
+
+  .vc-year{
+    --tw-text-opacity: 1;
+    color: rgb(229 229 229 / var(--tw-text-opacity, 1));
+  }
+}
+
+.vc-year {
+
+  &:hover,
+  &:focus{
+    --tw-text-opacity: 1;
+    color: rgb(75 85 99 / var(--tw-text-opacity, 1));
+  }
+
+  @media (prefers-color-scheme: dark){
+
+    &:hover,
+  &:focus{
+      --tw-text-opacity: 1;
+      color: rgb(212 212 212 / var(--tw-text-opacity, 1));
+    }
+  }
+}
+
+.vc-arrow{
+  display: flex;
+  width: 2rem;
+  height: 2rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  --tw-text-opacity: 1;
+  color: rgb(31 41 55 / var(--tw-text-opacity, 1));
+}
+
+@media (prefers-color-scheme: dark){
+
+  .vc-arrow{
+    --tw-text-opacity: 1;
+    color: rgb(163 163 163 / var(--tw-text-opacity, 1));
+  }
+}
+
+.vc-arrow {
+
+  &:hover,
+  &:focus{
+    --tw-bg-opacity: 1;
+    background-color: rgb(243 244 246 / var(--tw-bg-opacity, 1));
+  }
+
+  @media (prefers-color-scheme: dark){
+
+    &:hover,
+  &:focus{
+      --tw-bg-opacity: 1;
+      background-color: rgb(38 38 38 / var(--tw-bg-opacity, 1));
+    }
+  }
+
+  &:focus{
+    outline: 0;
+  }
+
+  &:disabled,
+  &.disabled{
+    pointer-events: none;
+  }
+
+  &:disabled,
+  &.disabled{
+    opacity: 0.5;
+  }
+}
+
 *, ::before, ::after{
   --tw-border-spacing-x: 0;
   --tw-border-spacing-y: 0;
@@ -120,14 +923,10 @@
 *,
 ::before,
 ::after {
-  box-sizing: border-box;
-  /* 1 */
-  border-width: 0;
-  /* 2 */
-  border-style: solid;
-  /* 2 */
-  border-color: #e5e7eb;
-  /* 2 */
+  box-sizing: border-box; /* 1 */
+  border-width: 0; /* 2 */
+  border-style: solid; /* 2 */
+  border-color: #e5e7eb; /* 2 */
 }
 
 ::before,
@@ -147,23 +946,15 @@
 
 html,
 :host {
-  line-height: 1.5;
-  /* 1 */
-  -webkit-text-size-adjust: 100%;
-  /* 2 */
-  -moz-tab-size: 4;
-  /* 3 */
+  line-height: 1.5; /* 1 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+  -moz-tab-size: 4; /* 3 */
   -o-tab-size: 4;
-     tab-size: 4;
-  /* 3 */
-  font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  /* 4 */
-  font-feature-settings: normal;
-  /* 5 */
-  font-variation-settings: normal;
-  /* 6 */
-  -webkit-tap-highlight-color: transparent;
-  /* 7 */
+     tab-size: 4; /* 3 */
+  font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"; /* 4 */
+  font-feature-settings: normal; /* 5 */
+  font-variation-settings: normal; /* 6 */
+  -webkit-tap-highlight-color: transparent; /* 7 */
 }
 
 /*
@@ -172,10 +963,8 @@ html,
 */
 
 body {
-  margin: 0;
-  /* 1 */
-  line-height: inherit;
-  /* 2 */
+  margin: 0; /* 1 */
+  line-height: inherit; /* 2 */
 }
 
 /*
@@ -185,12 +974,9 @@ body {
 */
 
 hr {
-  height: 0;
-  /* 1 */
-  color: inherit;
-  /* 2 */
-  border-top-width: 1px;
-  /* 3 */
+  height: 0; /* 1 */
+  color: inherit; /* 2 */
+  border-top-width: 1px; /* 3 */
 }
 
 /*
@@ -245,14 +1031,10 @@ code,
 kbd,
 samp,
 pre {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  /* 1 */
-  font-feature-settings: normal;
-  /* 2 */
-  font-variation-settings: normal;
-  /* 3 */
-  font-size: 1em;
-  /* 4 */
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; /* 1 */
+  font-feature-settings: normal; /* 2 */
+  font-variation-settings: normal; /* 3 */
+  font-size: 1em; /* 4 */
 }
 
 /*
@@ -290,12 +1072,9 @@ sup {
 */
 
 table {
-  text-indent: 0;
-  /* 1 */
-  border-color: inherit;
-  /* 2 */
-  border-collapse: collapse;
-  /* 3 */
+  text-indent: 0; /* 1 */
+  border-color: inherit; /* 2 */
+  border-collapse: collapse; /* 3 */
 }
 
 /*
@@ -309,26 +1088,16 @@ input,
 optgroup,
 select,
 textarea {
-  font-family: inherit;
-  /* 1 */
-  font-feature-settings: inherit;
-  /* 1 */
-  font-variation-settings: inherit;
-  /* 1 */
-  font-size: 100%;
-  /* 1 */
-  font-weight: inherit;
-  /* 1 */
-  line-height: inherit;
-  /* 1 */
-  letter-spacing: inherit;
-  /* 1 */
-  color: inherit;
-  /* 1 */
-  margin: 0;
-  /* 2 */
-  padding: 0;
-  /* 3 */
+  font-family: inherit; /* 1 */
+  font-feature-settings: inherit; /* 1 */
+  font-variation-settings: inherit; /* 1 */
+  font-size: 100%; /* 1 */
+  font-weight: inherit; /* 1 */
+  line-height: inherit; /* 1 */
+  letter-spacing: inherit; /* 1 */
+  color: inherit; /* 1 */
+  margin: 0; /* 2 */
+  padding: 0; /* 3 */
 }
 
 /*
@@ -349,12 +1118,9 @@ button,
 input:where([type='button']),
 input:where([type='reset']),
 input:where([type='submit']) {
-  -webkit-appearance: button;
-  /* 1 */
-  background-color: transparent;
-  /* 2 */
-  background-image: none;
-  /* 2 */
+  -webkit-appearance: button; /* 1 */
+  background-color: transparent; /* 2 */
+  background-image: none; /* 2 */
 }
 
 /*
@@ -396,10 +1162,8 @@ Correct the cursor style of increment and decrement buttons in Safari.
 */
 
 [type='search'] {
-  -webkit-appearance: textfield;
-  /* 1 */
-  outline-offset: -2px;
-  /* 2 */
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
 }
 
 /*
@@ -416,10 +1180,8 @@ Remove the inner padding in Chrome and Safari on macOS.
 */
 
 ::-webkit-file-upload-button {
-  -webkit-appearance: button;
-  /* 1 */
-  font: inherit;
-  /* 2 */
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
 }
 
 /*
@@ -489,18 +1251,14 @@ textarea {
 */
 
 input::-moz-placeholder, textarea::-moz-placeholder {
-  opacity: 1;
-  /* 1 */
-  color: #9ca3af;
-  /* 2 */
+  opacity: 1; /* 1 */
+  color: #9ca3af; /* 2 */
 }
 
 input::placeholder,
 textarea::placeholder {
-  opacity: 1;
-  /* 1 */
-  color: #9ca3af;
-  /* 2 */
+  opacity: 1; /* 1 */
+  color: #9ca3af; /* 2 */
 }
 
 /*
@@ -534,10 +1292,8 @@ audio,
 iframe,
 embed,
 object {
-  display: block;
-  /* 1 */
-  vertical-align: middle;
-  /* 2 */
+  display: block; /* 1 */
+  vertical-align: middle; /* 2 */
 }
 
 /*
@@ -1150,6 +1906,7 @@ img{
 }
 
 @media (min-width: 640px){
+
   .sm\:text-sm{
     font-size: 0.875rem;
     line-height: 1.25rem;
@@ -1157,6 +1914,7 @@ img{
 }
 
 @media (prefers-color-scheme: dark){
+
   .dark\:border-neutral-700{
     --tw-border-opacity: 1;
     border-color: rgb(64 64 64 / var(--tw-border-opacity, 1));

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,11 +1,11 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
 
+@import "@preline/datepicker/variants.css";
+@import "./preline-datepicker.css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import "@preline/datepicker/variants.css";
-@import "@preline/datepicker/styles.css";
 
 
 body {

--- a/src/assets/preline-datepicker.css
+++ b/src/assets/preline-datepicker.css
@@ -1,0 +1,217 @@
+
+.vc {
+  @apply bg-white border border-gray-200 shadow-lg rounded-xl dark:bg-neutral-900 dark:border-neutral-700;
+
+  &[data-vc-input] {
+    @apply absolute;
+  }
+
+  &[data-vc-type="default"] {
+    @apply p-3;
+  }
+
+  &[data-vc-type="multiple"] {
+    @apply w-80 sm:w-160 py-3;
+  }
+
+  &[data-vc-calendar-hidden] {
+    @apply hidden;
+  }
+}
+
+.vc-week {
+  @apply flex pb-1.5;
+}
+
+.vc-week__day {
+  @apply m-px w-10 block font-normal text-center text-sm text-gray-500 dark:text-neutral-500;
+
+  &:focus {
+    @apply outline-hidden;
+  }
+}
+
+.vc-dates {
+  @apply grid grid-cols-7 gap-y-0.5;
+}
+
+.vc-date {
+  @apply relative size-10.5 flex justify-center items-center text-sm text-gray-800 rounded-full dark:text-neutral-200;
+
+  &:empty {
+    @apply invisible;
+  }
+
+  &:hover {
+    @apply text-blue-600;
+
+    &::before {
+      @apply border-blue-600;
+    }
+  }
+
+  &:nth-child(7n) {
+    @apply rounded-r-full;
+  }
+
+  &:nth-child(7n+1) {
+    @apply rounded-l-full;
+  }
+
+  &::before {
+    content: "";
+    @apply absolute inset-0 size-full border-[1.5px] border-transparent rounded-full;
+  }
+
+  button {
+    @apply relative size-full rounded-full;
+  }
+
+  &[data-vc-date-month="prev"],
+  &[data-vc-date-month="next"] {
+    @apply text-gray-400 dark:text-neutral-600;
+  }
+
+  &[data-vc-date-today] {
+    @apply bg-blue-600 text-white;
+  }
+
+  &[data-vc-date-selected] {
+    @apply bg-blue-600;
+
+    &:not([data-vc-date-selected="middle"]) {
+      @apply text-white;
+    }
+
+    &[data-vc-date-hover="first-and-last"] {
+      @apply rounded-full;
+    }
+  }
+
+  &[data-vc-date-hover="first"],
+  &[data-vc-date-selected="first"] {
+    @apply rounded-l-full rounded-r-none;
+
+    &::before {
+      @apply rounded-l-full rounded-r-none;
+    }
+  }
+
+  &[data-vc-date-hover="last"],
+  &[data-vc-date-selected="last"] {
+    @apply rounded-r-full rounded-l-none;
+
+    &::before {
+      @apply rounded-r-full rounded-l-none;
+    }
+  }
+
+  &[data-vc-date-hover="first"][data-vc-date-selected],
+  &[data-vc-date-hover="last"][data-vc-date-selected],
+  &[data-vc-date-selected="first"],
+  &[data-vc-date-selected="last"] {
+    @apply text-white;
+
+    &::before {
+      @apply bg-blue-600;
+    }
+  }
+
+  &[data-vc-date-hover],
+  &[data-vc-date-selected="middle"] {
+    &:not([data-vc-date-hover="first"]):not([data-vc-date-hover="last"]):not([data-vc-date-hover="first-and-last"]) {
+      @apply rounded-none;
+    }
+
+    &:not([data-vc-date-today]):not([data-vc-date-hover="first-and-last"]) {
+      @apply bg-gray-100 dark:bg-neutral-800;
+    }
+  }
+}
+
+.vc-months {
+  @apply grid grid-cols-4 gap-3;
+}
+
+.vc-months__month {
+  @apply py-2 px-3 inline-flex items-center gap-x-2 text-sm font-medium rounded-lg border border-gray-200 text-gray-800 dark:border-neutral-700 dark:text-neutral-200;
+
+  &:hover {
+    @apply border-gray-300 text-gray-500 dark:border-neutral-600 dark:text-neutral-500;
+  }
+
+  &:focus {
+    @apply outline-none border-gray-300 text-gray-500 dark:border-neutral-600 dark:text-neutral-500;
+  }
+
+  &:disabled,
+  &.disabled {
+    @apply opacity-50 pointer-events-none;
+  }
+
+  &[data-vc-months-month-selected] {
+    @apply bg-blue-600 border-blue-600 text-white dark:bg-blue-500 dark:border-blue-500;
+  }
+}
+
+.vc-month {
+  @apply text-gray-800 dark:text-neutral-200;
+
+  &:hover,
+  &:focus {
+    @apply text-gray-600 dark:text-neutral-300;
+  }
+}
+
+.vc-years {
+  @apply grid grid-cols-5 gap-2;
+}
+
+.vc-years__year {
+  @apply py-2 px-3 inline-flex items-center gap-x-2 text-sm font-medium rounded-lg border border-gray-200 text-gray-800 dark:border-neutral-700 dark:text-neutral-200;
+
+  &:hover,
+  &:focus {
+    @apply border-gray-300 text-gray-500 dark:border-neutral-600 dark:text-neutral-500;
+  }
+
+  &:focus {
+    @apply outline-none;
+  }
+
+  &:disabled,
+  &.disabled {
+    @apply opacity-50 pointer-events-none;
+  }
+
+  &[data-vc-years-year-selected] {
+    @apply bg-blue-600 border-blue-600 text-white dark:bg-blue-500 dark:border-blue-500;
+  }
+}
+
+.vc-year {
+  @apply text-gray-800 dark:text-neutral-200;
+
+  &:hover,
+  &:focus {
+    @apply text-gray-600 dark:text-neutral-300;
+  }
+}
+
+.vc-arrow {
+  @apply size-8 flex justify-center items-center text-gray-800 rounded-full dark:text-neutral-400;
+
+  &:hover,
+  &:focus {
+    @apply bg-gray-100 dark:bg-neutral-800;
+  }
+
+  &:focus {
+    @apply outline-hidden;
+  }
+
+  &:disabled,
+  &.disabled {
+    @apply opacity-50 pointer-events-none;
+  }
+}

--- a/src/components/PrelineDatepicker.vue
+++ b/src/components/PrelineDatepicker.vue
@@ -11,7 +11,7 @@
 
 <script setup>
 import { onMounted, ref } from 'vue'
-import { Datepicker as VCalendar } from 'vanillajs-datepicker'
+import HSDatepicker from '@preline/datepicker'
 
 const datepicker = ref(null)
 
@@ -28,11 +28,8 @@ const config = JSON.stringify({
 })
 
 onMounted(() => {
-  if (window.hs?.Datepicker) {
-    window.hs.Datepicker.autoInit()
-  } else {
-    // Fallback if Preline doesn't load
-    new VCalendar(datepicker.value)
+  if (datepicker.value) {
+    new HSDatepicker(datepicker.value)
   }
 })
 </script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,6 @@ import { createApp } from 'vue'
 import router from './router'
 import AppRoot from './AppRoot.vue'
 import * as ImageKitVue from '@imagekit/vue'  // Namespace import
-import 'vanillajs-datepicker/css/datepicker.min.css'
 import 'preline/dist/preline.js'
 import '@preline/datepicker'
 // import { Datepicker } from 'preline' // Optional: manual init

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 import preline from 'preline/plugin'
+import plugin from 'tailwindcss/plugin'
 
 export default {
   content: [
@@ -7,7 +8,22 @@ export default {
     './src/**/*.{vue,js,ts,jsx,tsx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      spacing: {
+        10.5: '2.625rem',
+        160: '40rem'
+      },
+      width: {
+        160: '40rem'
+      }
+    }
   },
-  plugins: [preline],
+  plugins: [
+    preline,
+    plugin(function({ addUtilities }) {
+      addUtilities({
+        '.outline-hidden': { outline: '0' }
+      })
+    })
+  ],
 }


### PR DESCRIPTION
## Summary
- load Preline datepicker plugin without fallback
- drop extra vanillajs CSS so Preline styles apply correctly
- compile Preline datepicker CSS with postcss

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68543bd89d4c8320a9eb8f0a21bf15a1