### PR TITLE
Fix DatePicker not saving value

### DIFF
--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -28,9 +28,11 @@ onMounted(() => {
   if (inputRef.value) {
     calendar = new Calendar(inputRef.value, { inputMode: true });
     calendar.init();
-    inputRef.value.addEventListener('change', (e: Event) => {
+    const updateValue = (e: Event) => {
       emit('update:modelValue', (e.target as HTMLInputElement).value);
-    });
+    };
+    inputRef.value.addEventListener('input', updateValue);
+    inputRef.value.addEventListener('change', updateValue);
     if (props.modelValue) {
       inputRef.value.value = props.modelValue;
     }


### PR DESCRIPTION
## Summary
- listen to `input` events in `DatePicker` so edits propagate correctly

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685485560a3c83208be7b2ab07aa2367