### PR TITLE
Fix date saving for edit item

### DIFF
--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -26,7 +26,12 @@ let calendar: Calendar | null = null;
 
 onMounted(() => {
   if (inputRef.value) {
-    calendar = new Calendar(inputRef.value, { inputMode: true });
+    calendar = new Calendar(inputRef.value, {
+      inputMode: true,
+      onChangeToInput: (_self: Calendar, e: Event) => {
+        emit('update:modelValue', (e.target as HTMLInputElement).value);
+      }
+    });
     calendar.init();
     const updateValue = (e: Event) => {
       emit('update:modelValue', (e.target as HTMLInputElement).value);

--- a/src/components/EditItemForm.vue
+++ b/src/components/EditItemForm.vue
@@ -214,6 +214,29 @@ function removeTag(index: number) {
   form.value.tags.splice(index, 1);
 }
 
+function toISODate(input: string): string {
+  const parsed = new Date(input);
+  if (!isNaN(parsed.getTime())) {
+    return parsed.toISOString();
+  }
+  const parts = input.split(/[./-]/);
+  if (parts.length === 3) {
+    let year = parts[0];
+    let month = parts[1];
+    let day = parts[2];
+    if (year.length !== 4) {
+      day = parts[0];
+      month = parts[1];
+      year = parts[2];
+    }
+    const iso = new Date(`${year}-${month}-${day}T00:00:00.000Z`);
+    if (!isNaN(iso.getTime())) {
+      return iso.toISOString();
+    }
+  }
+  return new Date().toISOString();
+}
+
 async function handleSubmit() {
   try {
     let imageUrl = props.item.imageUrl;
@@ -240,7 +263,7 @@ async function handleSubmit() {
         price: form.value.price,
         fee_percent: form.value.feePercent,
         image_url: imageUrl,
-        date_added: new Date(form.value.dateAdded).toISOString(),
+        date_added: toISODate(form.value.dateAdded),
         tags: form.value.tags
       })
       .eq('id', props.item.id)


### PR DESCRIPTION
## Summary
- ensure the date picker value is converted to ISO when updating items
- emit change events from the calendar when selecting dates

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6854b2abd94c8320b417a8f17e37b71e