### PR TITLE
Improve date picker sync with calendar

### DIFF
--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -28,20 +28,22 @@ onMounted(() => {
   if (inputRef.value) {
     calendar = new Calendar(inputRef.value, {
       inputMode: true,
-      onChangeToInput: (_self: Calendar, e: Event) => {
+      onChangeToInput: (self: Calendar, e: Event) => {
         const raw = (e.target as HTMLInputElement).value.trim();
         if (!raw) return;
         const parsed = new Date(raw);
         if (!isNaN(parsed.getTime())) {
           const val = parsed.toISOString().slice(0, 10);
-          if (inputRef.value) inputRef.value.value = val;
+          self.set({ selectedDates: [val] });
+          self.context.inputElement!.value = val;
           emit('update:modelValue', val);
         }
       },
       onClickDate: (self: Calendar) => {
         if (self.selectedDates && self.selectedDates[0]) {
           const val = new Date(self.selectedDates[0]).toISOString().slice(0, 10);
-          if (inputRef.value) inputRef.value.value = val;
+          self.set({ selectedDates: [val] });
+          self.context.inputElement!.value = val;
           emit('update:modelValue', val);
         }
       }


### PR DESCRIPTION
## Summary
- ensure Vanilla Calendar preserves selected date when picking a day

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68581d8ed66c83209b71bf8283590004