### PR TITLE
Add build docs and prebuild check

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ npm run dev
 npm run build
 ```
 
+**Note:** Run `npm install` before `npm run build` to ensure all dependencies like PostCSS are installed.
+
 ## Environment Variables
 Create a `.env` file based on `.env.example` and set the following variables:
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "scripts": {
         "dev": "vite",
         "build:css": "postcss ./src/assets/main.css -o ./public/main.css",
+        "prebuild": "node ./scripts/check-postcss.js",
         "build": "npm run build:css && vite build",
         "preview": "vite preview",
         "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix"

--- a/scripts/check-postcss.js
+++ b/scripts/check-postcss.js
@@ -1,0 +1,7 @@
+const fs = require('fs');
+const path = require('path');
+
+const postcssPath = path.join(__dirname, '..', 'node_modules', 'postcss');
+if (!fs.existsSync(postcssPath)) {
+  console.warn('Warning: postcss is not installed. Run `npm install` before building.');
+}


### PR DESCRIPTION
## Summary
- note in README that `npm install` must run before building
- add `prebuild` script to warn if PostCSS is missing

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68581e34ac888320b600f583d8312c1b