### PR TITLE
Add Preline datepicker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "dependencies": {
                 "@hcaptcha/vue3-hcaptcha": "^1.3.0",
                 "@imagekit/vue": "^4.0.0",
+                "@preline/datepicker": "^3.1.0",
                 "@supabase/supabase-js": "^2.49.8",
                 "chart.js": "^4.4.1",
                 "imagekit": "^4.1.3",
@@ -826,6 +827,12 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
             }
+        },
+        "node_modules/@preline/datepicker": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@preline/datepicker/-/datepicker-3.1.0.tgz",
+            "integrity": "sha512-I24IzsM8R9IeXxjLR41s8P0HHoO06a1VDSqXvHlxw9Zra73ZZp5z5EHSHIbcdu32kG252WoEjYEvT/lUavg5Dg==",
+            "license": "Licensed under MIT and Preline UI Fair Use License"
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
             "version": "4.40.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dependencies": {
         "@hcaptcha/vue3-hcaptcha": "^1.3.0",
         "@imagekit/vue": "^4.0.0",
+        "@preline/datepicker": "^3.1.0",
         "@supabase/supabase-js": "^2.49.8",
         "chart.js": "^4.4.1",
         "imagekit": "^4.1.3",
@@ -25,6 +26,7 @@
         "vue-router": "^4.5.1"
     },
     "devDependencies": {
+        "@eslint/js": "^8.44.0",
         "@types/node": "^18.16.19",
         "@typescript-eslint/eslint-plugin": "^8.34.0",
         "@typescript-eslint/parser": "^8.34.0",
@@ -32,7 +34,6 @@
         "@vue/tsconfig": "^0.4.0",
         "autoprefixer": "^10.4.14",
         "eslint": "^8.44.0",
-        "@eslint/js": "^8.44.0",
         "eslint-plugin-vue": "^9.15.1",
         "postcss": "^8.4.25",
         "postcss-cli": "^11.0.1",

--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -3,74 +3,52 @@
     ref="inputRef"
     type="text"
     :placeholder="placeholder"
-    class="w-full px-3 py-2 border border-gray-300 rounded"
+    class="hs-datepicker w-full px-3 py-2 border border-gray-300 rounded"
+    data-hs-datepicker
   >
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount, watch } from 'vue';
-import { Calendar } from 'vanilla-calendar-pro';
-import 'vanilla-calendar-pro/styles/layout.css';
-import 'vanilla-calendar-pro/styles/themes/light.css';
-import 'vanilla-calendar-pro/styles/themes/dark.css';
+import { ref, onMounted, onBeforeUnmount, watch } from 'vue'
+import '@preline/datepicker/styles.css'
 
 const props = defineProps<{
-  modelValue: string;
-  placeholder?: string;
-}>();
+  modelValue: string
+  placeholder?: string
+}>()
 
-const emit = defineEmits<{ 'update:modelValue': [string] }>();
+const emit = defineEmits<{ 'update:modelValue': [string] }>()
 
-const inputRef = ref<HTMLInputElement | null>(null);
-let calendar: Calendar | null = null;
+const inputRef = ref<HTMLInputElement | null>(null)
+
+function updateValue(e: Event) {
+  emit('update:modelValue', (e.target as HTMLInputElement).value)
+}
 
 onMounted(() => {
   if (inputRef.value) {
-    calendar = new Calendar(inputRef.value, {
-      inputMode: true,
-      onChangeToInput: (self: Calendar, e: Event) => {
-        const raw = (e.target as HTMLInputElement).value.trim();
-        if (!raw) return;
-        const parsed = new Date(raw);
-        if (!isNaN(parsed.getTime())) {
-          const val = parsed.toISOString().slice(0, 10);
-          self.set({ selectedDates: [val] });
-          self.context.inputElement!.value = val;
-          emit('update:modelValue', val);
-        }
-      },
-      onClickDate: (self: Calendar) => {
-        if (self.selectedDates && self.selectedDates[0]) {
-          const val = new Date(self.selectedDates[0]).toISOString().slice(0, 10);
-          self.set({ selectedDates: [val] });
-          self.context.inputElement!.value = val;
-          emit('update:modelValue', val);
-        }
-      }
-    });
-    calendar.init();
-    const updateValue = (e: Event) => {
-      const val = (e.target as HTMLInputElement).value.trim();
-      if (val) emit('update:modelValue', val);
-    };
-    inputRef.value.addEventListener('input', updateValue);
-    inputRef.value.addEventListener('change', updateValue);
+    inputRef.value.addEventListener('change', updateValue)
+    inputRef.value.addEventListener('input', updateValue)
     if (props.modelValue) {
-      inputRef.value.value = props.modelValue;
+      inputRef.value.value = props.modelValue
     }
   }
-});
+})
 
 onBeforeUnmount(() => {
-  calendar?.destroy();
-});
+  if (inputRef.value) {
+    inputRef.value.removeEventListener('change', updateValue)
+    inputRef.value.removeEventListener('input', updateValue)
+  }
+})
 
 watch(
   () => props.modelValue,
   (val) => {
     if (inputRef.value && inputRef.value.value !== val) {
-      inputRef.value.value = val;
+      inputRef.value.value = val
     }
   }
-);
+)
 </script>
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import router from './router'
 import AppRoot from './AppRoot.vue'
 import * as ImageKitVue from '@imagekit/vue'  // Namespace import
 import 'preline/dist/preline'
+import '@preline/datepicker'
 // import { Datepicker } from 'preline' // Optional: manual init
 
 const app = createApp(AppRoot)


### PR DESCRIPTION
## Summary
- install `@preline/datepicker` plugin
- switch `DatePicker.vue` to use Preline's datepicker
- load the datepicker plugin in `main.ts`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685826f280ec8320bb71a4608a3ea601