### PR TITLE
Initialize Preline on app mount

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import * as ImageKitVue from '@imagekit/vue'  // Namespace import
 import 'preline/dist/preline'
 import '@preline/datepicker'
 // import { Datepicker } from 'preline' // Optional: manual init
+import { HSStaticMethods } from 'preline'
 
 const app = createApp(AppRoot)
 
@@ -17,3 +18,4 @@ app.use(ImageKitVue, {
 })
 
 app.mount('#app')
+HSStaticMethods.autoInit()


### PR DESCRIPTION
## Summary
- import `HSStaticMethods` from `preline`
- call `HSStaticMethods.autoInit()` after mounting the app

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68582a8f228c8320942df142dcca35d6