### PR TITLE
Fix Vite config and confirm build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,13 +5,7 @@ import vue from '@vitejs/plugin-vue'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [vue()],
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
-    }
-  },
-  css: {
-    postcss: './postcss.config.js', // If you have PostCSS config
-  }
+  resolve: { alias: { '@': fileURLToPath(new URL('./src', import.meta.url)) } },
+  css: { postcss: './postcss.config.js' },
+  build: { rollupOptions: { external: ['tailwindcss'] } }
 })
-


### PR DESCRIPTION
## Summary
- configure Vite to use PostCSS and treat tailwindcss as an external dependency

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6858abb6afc083208252a75df8f307d8