### PR TITLE
Fix datepicker css with Tailwind import

### DIFF
--- a/src/assets/datepicker.css
+++ b/src/assets/datepicker.css
@@ -1,3 +1,4 @@
+@import "tailwindcss";
 .vc {
   @apply bg-white border border-gray-200 shadow-lg rounded-xl dark:bg-neutral-900 dark:border-neutral-700;
 

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,10 +1,10 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
+@import "./datepicker.css";
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-@import './datepicker.css';
 
 
 body {


### PR DESCRIPTION
## Summary
- ensure Tailwind utilities are available in `datepicker.css`
- move `datepicker.css` import before Tailwind directives

## Testing
- `npm run lint` *(fails: ReferenceError require is not defined)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685970fbfd0c8320a99017332b09af4f