### PR TITLE
Fix Preline datepicker initialization

### DIFF
--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -5,6 +5,7 @@
     :placeholder="placeholder"
     class="hs-datepicker w-full px-3 py-2 border border-gray-300 rounded"
     data-hs-datepicker
+    data-hs-datepicker-options='{"dateFormat":"YYYY-MM-DD"}'
   >
 </template>
 
@@ -26,6 +27,8 @@ function updateValue(e: Event) {
 
 onMounted(() => {
   if (inputRef.value) {
+    // Initialize Preline plugins so HSDatepicker works
+    (window as any).HSStaticMethods?.autoInit?.();
     inputRef.value.addEventListener('change', updateValue)
     inputRef.value.addEventListener('input', updateValue)
     if (props.modelValue) {


### PR DESCRIPTION
## Summary
- ensure Preline datepicker initializes and outputs ISO formatted dates

## Testing
- `npm run lint` *(fails: require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685975284cb48320becc66edc3e3bb4f