### PR TITLE
Use HSDatepicker autoInit

### DIFF
--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -29,6 +29,7 @@ onMounted(() => {
   if (inputRef.value) {
     // Initialize Preline plugins so HSDatepicker works
     (window as any).HSStaticMethods?.autoInit?.();
+    (window as any).HSDatepicker?.autoInit?.();
     inputRef.value.addEventListener('change', updateValue)
     inputRef.value.addEventListener('input', updateValue)
     if (props.modelValue) {


### PR DESCRIPTION
## Summary
- auto initialize the date picker using `HSDatepicker.autoInit`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68598445fec08320b35954b7ae0b3837