### PR TITLE
Fix HSDatepicker autoInit runtime error

### DIFF
--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -29,6 +29,7 @@ onMounted(() => {
   if (inputRef.value) {
     // Initialize Preline plugins so HSDatepicker works
     (window as any).HSStaticMethods?.autoInit?.();
+    (window as any).HSDatepicker?.autoInit?.();
     inputRef.value.addEventListener('change', updateValue)
     inputRef.value.addEventListener('input', updateValue)
     if (props.modelValue) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,9 +4,13 @@ import AppRoot from './AppRoot.vue'
 import * as ImageKitVue from '@imagekit/vue'  // Namespace import
 import 'preline/dist/preline'
 import '@preline/datepicker'
+import _ from 'lodash'
 // import { Datepicker } from 'preline' // Optional: manual init
 
 const app = createApp(AppRoot)
+
+// Expose lodash for Preline plugins that expect global `_`
+(window as any)._ = _
 
 app.use(router)
 


### PR DESCRIPTION
## Summary
- expose lodash as a global to satisfy Preline's HSDatepicker

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68598445fec08320b35954b7ae0b3837