### PR TITLE
Fix semicolon in main.ts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import '@preline/datepicker'
 import _ from 'lodash'
 // import { Datepicker } from 'preline' // Optional: manual init
 
-const app = createApp(AppRoot)
+const app = createApp(AppRoot);
 
 // Expose lodash for Preline plugins that expect global `_`
 (window as any)._ = _


### PR DESCRIPTION
## Summary
- add semicolon after `createApp` call in `main.ts`

## Testing
- `npm run lint` *(fails: ReferenceError: require is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_6859917db49c8320a88a71cd7c1ffd5e