### PR TITLE
Fix DatePicker format

### DIFF
--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -22,7 +22,10 @@ const emit = defineEmits<{ 'update:modelValue': [string] }>()
 const inputRef = ref<HTMLInputElement | null>(null)
 
 function updateValue(e: Event) {
-  emit('update:modelValue', (e.target as HTMLInputElement).value)
+  const raw = (e.target as HTMLInputElement).value
+  const normalized = raw.replace(/\./g, '-')
+  ;(e.target as HTMLInputElement).value = normalized
+  emit('update:modelValue', normalized)
 }
 
 onMounted(() => {
@@ -33,7 +36,7 @@ onMounted(() => {
     inputRef.value.addEventListener('change', updateValue)
     inputRef.value.addEventListener('input', updateValue)
     if (props.modelValue) {
-      inputRef.value.value = props.modelValue
+      inputRef.value.value = props.modelValue.replace(/\./g, '-')
     }
   }
 })
@@ -49,7 +52,7 @@ watch(
   () => props.modelValue,
   (val) => {
     if (inputRef.value && inputRef.value.value !== val) {
-      inputRef.value.value = val
+      inputRef.value.value = val.replace(/\./g, '-')
     }
   }
 )


### PR DESCRIPTION
## Summary
- normalize date value from Preline Datepicker
- ensure DatePicker emits `YYYY-MM-DD` values

## Testing
- `npm run lint` *(fails: require is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_685992fbb56c8320b07a2f1641c299cd