### PR TITLE
Fix DatePicker output format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
             "dependencies": {
                 "@hcaptcha/vue3-hcaptcha": "^1.3.0",
                 "@imagekit/vue": "^4.0.0",
-                "@preline/datepicker": "^3.1.0",
                 "@supabase/supabase-js": "^2.49.8",
                 "@tailwindcss/postcss": "^4.1.10",
                 "chart.js": "^4.4.1",
@@ -791,12 +790,6 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
             }
-        },
-        "node_modules/@preline/datepicker": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@preline/datepicker/-/datepicker-3.1.0.tgz",
-            "integrity": "sha512-I24IzsM8R9IeXxjLR41s8P0HHoO06a1VDSqXvHlxw9Zra73ZZp5z5EHSHIbcdu32kG252WoEjYEvT/lUavg5Dg==",
-            "license": "Licensed under MIT and Preline UI Fair Use License"
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
             "version": "4.40.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "dependencies": {
         "@hcaptcha/vue3-hcaptcha": "^1.3.0",
         "@imagekit/vue": "^4.0.0",
-        "@preline/datepicker": "^3.1.0",
         "@supabase/supabase-js": "^2.49.8",
         "@tailwindcss/postcss": "^4.1.10",
         "chart.js": "^4.4.1",

--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -1,16 +1,15 @@
 <template>
   <input
     ref="inputRef"
-    type="text"
+    type="date"
     :placeholder="placeholder"
-    class="hs-datepicker w-full px-3 py-2 border border-gray-300 rounded"
-    data-hs-datepicker
-    data-hs-datepicker-options='{"dateFormat":"YYYY-MM-DD","inputModeOptions":{"dateSeparator":"-"}}'
+    class="w-full px-3 py-2 border border-gray-300 rounded"
+    @input="onInput"
   >
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount, watch } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 
 const props = defineProps<{
   modelValue: string
@@ -21,38 +20,22 @@ const emit = defineEmits<{ 'update:modelValue': [string] }>()
 
 const inputRef = ref<HTMLInputElement | null>(null)
 
-function updateValue(e: Event) {
-  const raw = (e.target as HTMLInputElement).value
-  const normalized = raw.replace(/\./g, '-')
-  ;(e.target as HTMLInputElement).value = normalized
-  emit('update:modelValue', normalized)
+function onInput(e: Event) {
+  const val = (e.target as HTMLInputElement).value
+  emit('update:modelValue', val)
 }
 
 onMounted(() => {
-  if (inputRef.value) {
-    // Initialize Preline plugins so HSDatepicker works
-    (window as any).HSStaticMethods?.autoInit?.();
-    (window as any).HSDatepicker?.autoInit?.();
-    inputRef.value.addEventListener('change', updateValue)
-    inputRef.value.addEventListener('input', updateValue)
-    if (props.modelValue) {
-      inputRef.value.value = props.modelValue.replace(/\./g, '-')
-    }
-  }
-})
-
-onBeforeUnmount(() => {
-  if (inputRef.value) {
-    inputRef.value.removeEventListener('change', updateValue)
-    inputRef.value.removeEventListener('input', updateValue)
+  if (inputRef.value && props.modelValue) {
+    inputRef.value.value = props.modelValue.slice(0, 10)
   }
 })
 
 watch(
   () => props.modelValue,
   (val) => {
-    if (inputRef.value && inputRef.value.value !== val) {
-      inputRef.value.value = val.replace(/\./g, '-')
+    if (inputRef.value && inputRef.value !== document.activeElement) {
+      inputRef.value.value = val.slice(0, 10)
     }
   }
 )

--- a/src/components/EditItemForm.vue
+++ b/src/components/EditItemForm.vue
@@ -215,8 +215,9 @@ function removeTag(index: number) {
 }
 
 function toISODate(input: string): string | null {
-  if (/^\d{4}-\d{2}-\d{2}$/.test(input)) {
-    const parsed = new Date(`${input}T00:00:00.000Z`);
+  const normalized = input.replace(/[.\/]/g, '-');
+  if (/^\d{4}-\d{2}-\d{2}$/.test(normalized)) {
+    const parsed = new Date(`${normalized}T00:00:00.000Z`);
     if (!isNaN(parsed.getTime())) {
       return parsed.toISOString();
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,6 @@ import router from './router'
 import AppRoot from './AppRoot.vue'
 import * as ImageKitVue from '@imagekit/vue'  // Namespace import
 import 'preline/dist/preline'
-import '@preline/datepicker'
 import _ from 'lodash'
 // import { Datepicker } from 'preline' // Optional: manual init
 


### PR DESCRIPTION
## Summary
- swap out HSDatepicker for a simple HTML date input
- normalize dotted dates when converting to ISO
- drop `@preline/datepicker` import and package

## Testing
- `npm run lint` *(fails: ReferenceError: require is not defined in ES module scope)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6859ac90d3a88320917b8cc5dd1d83ab