### PR TITLE
Improve build guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,9 @@ npm run lint
 npm run dev
 
 # Build for production
+# Make sure you've run `npm install` first so PostCSS and other dependencies are available.
 npm run build
 ```
-
-**Note:** Run `npm install` before `npm run build` to ensure all dependencies like PostCSS are installed.
 
 ## Environment Variables
 Copy `.env.example` to `.env` (which is ignored by Git) and set the following variables:

--- a/scripts/check-postcss.cjs
+++ b/scripts/check-postcss.cjs
@@ -2,6 +2,10 @@ const fs = require('fs');
 const path = require('path');
 
 const postcssPath = path.join(__dirname, '..', 'node_modules', 'postcss');
-if (!fs.existsSync(postcssPath)) {
-  console.warn('Warning: postcss is not installed. Run `npm install` before building.');
+const postcssCliPath = path.join(__dirname, '..', 'node_modules', 'postcss-cli');
+
+if (!fs.existsSync(postcssPath) || !fs.existsSync(postcssCliPath)) {
+  console.warn(
+    'Warning: postcss or postcss-cli is missing. Run `npm install` before building.'
+  );
 }


### PR DESCRIPTION
## Summary
- clarify that `npm install` must be run before `npm run build`
- warn if either `postcss` or `postcss-cli` isn't installed

## Testing
- `npm run prebuild`
- `npm run lint` *(fails: require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6859b1f3872c832092ab0c908049d8b1