### PR TITLE
Skip intro video for 48 hours

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -161,6 +161,7 @@ const searchQuery = ref('');
 const selectedImage = ref<string | null>(null);
 
 async function signOut() {
+  document.cookie = 'introShown=; path=/; max-age=0';
   await supabase.auth.signOut();
 }
 

--- a/src/AppRoot.vue
+++ b/src/AppRoot.vue
@@ -27,10 +27,17 @@ const showLanding = ref(true);
 const loggedIn = ref(false);
 
 onMounted(async () => {
-  setTimeout(() => {
+  // Skip intro video if cookie already set
+  if (document.cookie.includes('introShown=true')) {
     showLanding.value = false;
     document.body.style.backgroundColor = '#f3f4f6';
-  }, 5000);
+  } else {
+    setTimeout(() => {
+      showLanding.value = false;
+      document.cookie = 'introShown=true; path=/; max-age=172800';
+      document.body.style.backgroundColor = '#f3f4f6';
+    }, 5000);
+  }
   const { data } = await supabase.auth.getSession();
   loggedIn.value = !!data.session;
 });

--- a/src/components/EditItemForm.vue
+++ b/src/components/EditItemForm.vue
@@ -215,7 +215,8 @@ function removeTag(index: number) {
 }
 
 function toISODate(input: string): string | null {
-  const normalized = input.replace(/[.\/]/g, '-');
+  // Replace dots, forward slashes and backslashes with dashes
+  const normalized = input.replace(/[./\\]/g, '-');
   if (/^\d{4}-\d{2}-\d{2}$/.test(normalized)) {
     const parsed = new Date(`${normalized}T00:00:00.000Z`);
     if (!isNaN(parsed.getTime())) {


### PR DESCRIPTION
## Summary
- shorten intro cookie duration to 48 hours
- clear intro cookie when logging out

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6859bb5764708320852c78d396871ba7