### PR TITLE
Fix date formatting bug

### DIFF
--- a/src/components/ItemCard.vue
+++ b/src/components/ItemCard.vue
@@ -153,10 +153,14 @@ const handleViewImage = () => {
 
 const formattedDate = computed(() => {
   try {
-    return new Date(props.item.dateAdded).toLocaleDateString();
+    const d = new Date(props.item.dateAdded);
+    if (!isNaN(d.getTime())) {
+      return d.toISOString().split('T')[0];
+    }
   } catch {
-    return props.item.dateAdded;
+    // ignore
   }
+  return props.item.dateAdded;
 });
 
 


### PR DESCRIPTION
## Summary
- ensure dates render using ISO string so editing doesn't show a different day

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6859f02f7ac883208fe7768cbf70641f