### PR TITLE
Improve stats UI styling

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,7 @@
         Artwork Tracker
       </h1>
       <button
-        class="text-sm text-blue-500 hover:underline"
+        class="bg-red-500 hover:bg-red-600 text-white text-sm px-3 py-1 rounded"
         @click="signOut"
       >
         Sign Out
@@ -16,7 +16,7 @@
 
     <div class="flex justify-end mb-2">
       <button
-        class="text-sm text-blue-500 hover:underline"
+        class="bg-blue-500 hover:bg-blue-600 text-white text-sm px-3 py-1 rounded"
         @click="showChart = !showChart"
       >
         {{ showChart ? 'Hide Chart' : 'Show Chart' }}

--- a/src/components/StatsDisplay.vue
+++ b/src/components/StatsDisplay.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="flex space-x-4 mb-6">
-    <div class="bg-gray-100 p-4 rounded text-center">
+  <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
+    <div class="bg-white border rounded-lg shadow p-4 text-center">
       <p class="text-sm text-gray-600">
         Items
       </p>
@@ -8,7 +8,7 @@
         {{ props.stats.items }}
       </p>
     </div>
-    <div class="bg-gray-100 p-4 rounded text-center">
+    <div class="bg-white border rounded-lg shadow p-4 text-center">
       <p class="text-sm text-gray-600">
         Sold
       </p>
@@ -16,7 +16,7 @@
         {{ props.stats.sold }}
       </p>
     </div>
-    <div class="bg-gray-100 p-4 rounded text-center">
+    <div class="bg-white border rounded-lg shadow p-4 text-center">
       <p class="text-sm text-gray-600">
         Paid
       </p>
@@ -24,7 +24,7 @@
         {{ props.stats.sold_paid }}
       </p>
     </div>
-    <div class="bg-gray-100 p-4 rounded text-center">
+    <div class="bg-white border rounded-lg shadow p-4 text-center">
       <p class="text-sm text-gray-600">
         Paid Total
       </p>


### PR DESCRIPTION
## Summary
- style stats widgets with white cards
- style chart toggle and sign-out buttons

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685aa8e382c8832089acc1ca659238ea