### PR TITLE
Update StatsDisplay style

### DIFF
--- a/src/components/StatsDisplay.vue
+++ b/src/components/StatsDisplay.vue
@@ -1,36 +1,64 @@
 <template>
   <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
-    <div class="bg-white border rounded-lg shadow p-4 text-center">
-      <p class="text-sm text-gray-600">
-        Items
-      </p>
-      <p class="text-xl font-bold">
-        {{ props.stats.items }}
-      </p>
+    <!-- Items Card -->
+    <div class="flex flex-col bg-white border border-gray-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
+      <div class="p-4 md:p-5">
+        <div class="flex items-center gap-x-2">
+          <p class="text-xs uppercase text-gray-500 dark:text-neutral-500">
+            Items
+          </p>
+        </div>
+        <div class="mt-1 flex items-center gap-x-2">
+          <h3 class="text-xl sm:text-2xl font-medium text-gray-800 dark:text-neutral-200">
+            {{ props.stats.items }}
+          </h3>
+        </div>
+      </div>
     </div>
-    <div class="bg-white border rounded-lg shadow p-4 text-center">
-      <p class="text-sm text-gray-600">
-        Sold
-      </p>
-      <p class="text-xl font-bold">
-        {{ props.stats.sold }}
-      </p>
+    <!-- Sold Card -->
+    <div class="flex flex-col bg-white border border-gray-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
+      <div class="p-4 md:p-5">
+        <div class="flex items-center gap-x-2">
+          <p class="text-xs uppercase text-gray-500 dark:text-neutral-500">
+            Sold
+          </p>
+        </div>
+        <div class="mt-1 flex items-center gap-x-2">
+          <h3 class="text-xl sm:text-2xl font-medium text-gray-800 dark:text-neutral-200">
+            {{ props.stats.sold }}
+          </h3>
+        </div>
+      </div>
     </div>
-    <div class="bg-white border rounded-lg shadow p-4 text-center">
-      <p class="text-sm text-gray-600">
-        Paid
-      </p>
-      <p class="text-xl font-bold">
-        {{ props.stats.sold_paid }}
-      </p>
+    <!-- Paid Card -->
+    <div class="flex flex-col bg-white border border-gray-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
+      <div class="p-4 md:p-5">
+        <div class="flex items-center gap-x-2">
+          <p class="text-xs uppercase text-gray-500 dark:text-neutral-500">
+            Paid
+          </p>
+        </div>
+        <div class="mt-1 flex items-center gap-x-2">
+          <h3 class="text-xl sm:text-2xl font-medium text-gray-800 dark:text-neutral-200">
+            {{ props.stats.sold_paid }}
+          </h3>
+        </div>
+      </div>
     </div>
-    <div class="bg-white border rounded-lg shadow p-4 text-center">
-      <p class="text-sm text-gray-600">
-        Paid Total
-      </p>
-      <p class="text-xl font-bold">
-        ${{ props.stats.sold_paid_total.toFixed(2) }}
-      </p>
+    <!-- Paid Total Card -->
+    <div class="flex flex-col bg-white border border-gray-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
+      <div class="p-4 md:p-5">
+        <div class="flex items-center gap-x-2">
+          <p class="text-xs uppercase text-gray-500 dark:text-neutral-500">
+            Paid Total
+          </p>
+        </div>
+        <div class="mt-1 flex items-center gap-x-2">
+          <h3 class="text-xl sm:text-2xl font-medium text-gray-800 dark:text-neutral-200">
+            ${{ props.stats.sold_paid_total.toFixed(2) }}
+          </h3>
+        </div>
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- use Preline-style cards for stats display

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685ae604d45083209178b1f3faeb8867