### PR TITLE
Add optional table layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A single-page application built with Vue 3 and TypeScript for tracking items wit
 - Bar chart showing how many items were sold in the last 30 days, 6 months, and year
 - Record when each item was added and display this date
 - View all items in a responsive grid layout
+- Optional table layout with smaller thumbnails similar to a spreadsheet
 - Click an item's image to open a full-screen viewer with a close button
 - Persistent data storage using localStorage
 - Export items as a PDF file

--- a/src/App.vue
+++ b/src/App.vue
@@ -70,28 +70,46 @@
       </button>
     </div>
     
-    <div class="mb-4 flex items-center justify-between">
+    <div class="mb-4 flex flex-wrap items-center">
       <label
-        for="layout"
+        for="view"
         class="mr-2 text-sm text-gray-700"
-      >Layout:</label>
+      >View:</label>
       <select
-        id="layout"
-        v-model.number="columns"
+        id="view"
+        v-model="layout"
         class="border border-gray-300 rounded px-2 py-1 text-sm"
       >
-        <option :value="1">
-          1 column
+        <option value="grid">
+          Grid
         </option>
-        <option :value="2">
-          2 columns
-        </option>
-        <option :value="3">
-          3 columns
+        <option value="table">
+          Table
         </option>
       </select>
+      <template v-if="layout === 'grid'">
+        <label
+          for="columns"
+          class="ml-4 mr-2 text-sm text-gray-700"
+        >Columns:</label>
+        <select
+          id="columns"
+          v-model.number="columns"
+          class="border border-gray-300 rounded px-2 py-1 text-sm"
+        >
+          <option :value="1">
+            1 column
+          </option>
+          <option :value="2">
+            2 columns
+          </option>
+          <option :value="3">
+            3 columns
+          </option>
+        </select>
+      </template>
       <button
-        class="ml-4 text-sm text-blue-500 hover:underline"
+        class="ml-auto text-sm text-blue-500 hover:underline"
         @click="handleExportPdf"
       >
         Export PDF
@@ -121,15 +139,25 @@
       Loading items...
     </div>
     
-    <ItemGrid
-      v-else
-      :items="filteredItems"
-      :columns="columns"
-      @update-status="updateItemStatus"
-      @delete-item="deleteItem"
-      @edit-item="startEdit"
-      @view-image="openImageViewer"
-    />
+    <template v-else>
+      <ItemGrid
+        v-if="layout === 'grid'"
+        :items="filteredItems"
+        :columns="columns"
+        @update-status="updateItemStatus"
+        @delete-item="deleteItem"
+        @edit-item="startEdit"
+        @view-image="openImageViewer"
+      />
+      <ItemTable
+        v-else
+        :items="filteredItems"
+        @update-status="updateItemStatus"
+        @delete-item="deleteItem"
+        @edit-item="startEdit"
+        @view-image="openImageViewer"
+      />
+    </template>
     <ImageViewer
       v-if="selectedImage"
       :src="selectedImage"
@@ -143,6 +171,7 @@ import { ref, onMounted, watch, computed, nextTick } from 'vue';
 import ItemForm from './components/ItemForm.vue';
 import EditItemForm from './components/EditItemForm.vue';
 import ItemGrid from './components/ItemGrid.vue';
+import ItemTable from './components/ItemTable.vue';
 import StatsDisplay from './components/StatsDisplay.vue';
 import StatsChart from './components/StatsChart.vue';
 import ImageViewer from './components/ImageViewer.vue';
@@ -159,6 +188,7 @@ const DEBUG = import.meta.env.VITE_DEBUG === 'true';
 const items = ref<Item[]>([]);
 const showForm = ref(false);
 const showChart = ref(false);
+const layout = ref<'grid' | 'table'>('grid');
 const columns = ref(2);
 const isLoading = ref(true);
 const serverError = ref('');

--- a/src/components/ItemRow.vue
+++ b/src/components/ItemRow.vue
@@ -1,0 +1,140 @@
+<template>
+  <tr>
+    <td class="px-3 py-2">
+      <div class="relative w-12 h-12">
+        <img
+          v-if="item.imageUrl"
+          :src="imageToDisplay"
+          :alt="item.name"
+          class="w-12 h-12 object-cover cursor-pointer"
+          @error="handleImageError"
+          @click="handleViewImage"
+        >
+        <div
+          v-else
+          class="w-12 h-12 bg-gray-200 flex items-center justify-center text-xs text-gray-500"
+        >
+          No image
+        </div>
+        <span
+          v-if="isLocalImage"
+          class="absolute top-0 right-0 bg-yellow-100 text-yellow-800 text-[10px] px-1 rounded"
+        >Local</span>
+      </div>
+    </td>
+    <td class="px-3 py-2">
+      <div class="font-semibold">
+        {{ item.name }}
+      </div>
+      <div class="text-xs text-gray-500">
+        {{ formattedDate }}
+      </div>
+    </td>
+    <td class="px-3 py-2 text-sm text-gray-600">
+      {{ item.details }}
+    </td>
+    <td class="px-3 py-2 text-sm text-gray-600">
+      ${{ item.price }}
+    </td>
+    <td class="px-3 py-2 text-sm text-gray-600">
+      {{ item.location }}
+    </td>
+    <td class="px-3 py-2">
+      <select
+        :value="item.status"
+        class="border border-gray-300 rounded px-2 py-1 text-sm"
+        @change="handleStatusChange"
+      >
+        <option
+          v-for="option in statusOptions"
+          :key="option.value"
+          :value="option.value"
+        >
+          {{ option.label }}
+        </option>
+      </select>
+    </td>
+    <td class="px-3 py-2">
+      <div class="flex space-x-2">
+        <button
+          class="text-blue-500 hover:text-blue-700 text-sm font-medium"
+          @click="handleEdit"
+        >
+          Edit
+        </button>
+        <button
+          class="text-red-500 hover:text-red-700 text-sm font-medium"
+          @click="handleDelete"
+        >
+          Delete
+        </button>
+      </div>
+    </td>
+  </tr>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, defineProps, defineEmits } from 'vue'
+import type { Item } from '../types/item'
+import { statusOptions, DEFAULT_FALLBACK_IMAGE } from '../types/item'
+
+const props = defineProps<{
+  item: Item
+}>()
+
+const emit = defineEmits<{
+  'update-status': [string, 'not_sold' | 'sold' | 'sold_paid']
+  'delete-item': [string]
+  'edit-item': [Item]
+  'view-image': [string]
+}>()
+
+const imageError = ref(false)
+
+function handleImageError() {
+  imageError.value = true
+}
+
+function handleStatusChange(event: Event) {
+  const target = event.target as HTMLSelectElement
+  const newStatus = target.value as 'not_sold' | 'sold' | 'sold_paid'
+  emit('update-status', props.item.id, newStatus)
+}
+
+function handleDelete() {
+  emit('delete-item', props.item.id)
+}
+
+function handleEdit() {
+  emit('edit-item', props.item)
+}
+
+function handleViewImage() {
+  emit('view-image', imageToDisplay.value)
+}
+
+const formattedDate = computed(() => {
+  try {
+    const d = new Date(props.item.dateAdded)
+    if (!isNaN(d.getTime())) {
+      return d.toISOString().split('T')[0]
+    }
+  } catch {
+    // ignore
+  }
+  return props.item.dateAdded
+})
+
+const isLocalImage = computed(() => props.item.imageUrl?.startsWith('local:'))
+
+const imageToDisplay = computed(() => {
+  if (!props.item.imageUrl || imageError.value) {
+    return DEFAULT_FALLBACK_IMAGE
+  }
+  return props.item.imageUrl
+})
+</script>
+
+<style scoped>
+/* scoped styles if needed */
+</style>

--- a/src/components/ItemTable.vue
+++ b/src/components/ItemTable.vue
@@ -1,0 +1,67 @@
+<template>
+  <div
+    v-if="items.length === 0"
+    class="text-center text-gray-500 py-8"
+  >
+    No items added yet. Click "Add New Item" to get started.
+  </div>
+  <table
+    v-else
+    class="min-w-full divide-y divide-gray-200"
+  >
+    <thead class="bg-gray-50">
+      <tr>
+        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          Image
+        </th>
+        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          Name
+        </th>
+        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          Details
+        </th>
+        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          Price
+        </th>
+        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          Location
+        </th>
+        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          Status
+        </th>
+        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          Actions
+        </th>
+      </tr>
+    </thead>
+    <tbody class="bg-white divide-y divide-gray-200">
+      <ItemRow
+        v-for="item in items"
+        :key="item.id"
+        :item="item"
+        @update-status="(id, s) => $emit('update-status', id, s)"
+        @delete-item="id => $emit('delete-item', id)"
+        @edit-item="item => $emit('edit-item', item)"
+        @view-image="src => $emit('view-image', src)"
+      />
+    </tbody>
+  </table>
+</template>
+
+<script setup lang="ts">
+import ItemRow from './ItemRow.vue'
+import type { Item } from '../types/item'
+
+const { items } = defineProps<{ items: Item[] }>()
+
+defineEmits<{
+  'update-status': [string, 'not_sold' | 'sold' | 'sold_paid']
+  'delete-item': [string]
+  'edit-item': [Item]
+  'view-image': [string]
+}>()
+</script>
+
+<style scoped>
+/* optional styles */
+</style>


### PR DESCRIPTION
## Summary
- add `ItemRow` and `ItemTable` components for a spreadsheet‑like view
- add view selector with grid/table options in `App.vue`
- show `ItemTable` when table layout is selected
- document new table layout in README

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685b0f43d3dc832099eb65c47c2d0078