### PR TITLE
Add migration script for quantity and SKU fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A single-page application built with Vue 3 and TypeScript for tracking items wit
 ## Features
 
 - Add items with images, names, prices, locations, and detailed descriptions
+- Specify a quantity and optional SKU codes for each item
 - Set a custom shop fee percentage for each item (defaults to 20%)
 - Track item sales status (Not Sold / Sold / Paid)
 - Simple per-user statistics for Sold and Paid counts stored in Supabase, updated automatically when items change
@@ -107,6 +108,9 @@ the auth integration works, how to restrict data per user, and how to update an
 existing Supabase project for per-user items. A ready-to-run SQL script is
 available at [docs/SUPABASE_SETUP.sql](docs/SUPABASE_SETUP.sql) to create the
 required table, policies, and storage buckets.
+If you've already created the `items` table, run
+[docs/MIGRATION_ADD_QUANTITY_AND_SKU.sql](docs/MIGRATION_ADD_QUANTITY_AND_SKU.sql)
+to add the `quantity` and `sku_codes` columns.
 
 ## License
 

--- a/docs/MIGRATION_ADD_QUANTITY_AND_SKU.sql
+++ b/docs/MIGRATION_ADD_QUANTITY_AND_SKU.sql
@@ -1,0 +1,9 @@
+-- Migration script to add quantity and sku_codes columns
+-- Run this against an existing Supabase project to update the
+-- items table schema.
+
+alter table if exists public.items
+  add column if not exists quantity integer default 1;
+
+alter table if exists public.items
+  add column if not exists sku_codes text[];

--- a/docs/SUPABASE_SETUP.sql
+++ b/docs/SUPABASE_SETUP.sql
@@ -12,6 +12,8 @@ create table if not exists public.items (
   location text,
   price numeric,
   fee_percent numeric default 20,
+  quantity integer default 1,
+  sku_codes text[],
   image_url text,
   date_added timestamptz default now(),
   tags text[]

--- a/src/components/EditItemForm.vue
+++ b/src/components/EditItemForm.vue
@@ -46,6 +46,26 @@
     </div>
 
     <div class="mb-4">
+      <label class="block text-gray-700 font-medium mb-2">Quantity</label>
+      <input
+        v-model.number="form.quantity"
+        type="number"
+        class="w-full px-3 py-2 border border-gray-300 rounded"
+        min="1"
+      >
+    </div>
+
+    <div class="mb-4">
+      <label class="block text-gray-700 font-medium mb-2">SKU Codes</label>
+      <input
+        v-model="skuInput"
+        type="text"
+        class="w-full px-3 py-2 border border-gray-300 rounded"
+        placeholder="ABC123, ABC124"
+      >
+    </div>
+
+    <div class="mb-4">
       <label class="block text-gray-700 font-medium mb-2">Date Added</label>
       <DatePicker
         v-model="form.dateAdded"
@@ -160,6 +180,8 @@ const form = ref({
   location: props.item.location,
   price: props.item.price,
   feePercent: props.item.feePercent ?? 20,
+  quantity: props.item.quantity,
+  skuCodes: [...(props.item.skuCodes || [])],
   dateAdded: props.item.dateAdded.slice(0, 10),
   tags: [...(props.item.tags || [])]
 });
@@ -175,6 +197,11 @@ const displayPrice = computed({
 const selectedFile = ref<File | null>(null);
 const previewUrl = ref<string>(props.item.imageUrl);
 const tagInput = ref('');
+const skuInput = ref(form.value.skuCodes.join(', '));
+
+watch(skuInput, val => {
+  form.value.skuCodes = val.split(',').map(v => v.trim()).filter(Boolean);
+});
 
 watch(
   () => props.item,
@@ -186,6 +213,8 @@ watch(
       location: val.location,
       price: val.price,
       feePercent: val.feePercent ?? 20,
+      quantity: val.quantity,
+      skuCodes: [...(val.skuCodes || [])],
       dateAdded: val.dateAdded.slice(0, 10),
       tags: [...(val.tags || [])]
     };
@@ -256,6 +285,8 @@ async function handleSubmit() {
         status: form.value.status,
         location: form.value.location,
         price: form.value.price,
+        quantity: form.value.quantity,
+        sku_codes: form.value.skuCodes,
         fee_percent: form.value.feePercent,
         image_url: imageUrl,
         date_added: dateISO,

--- a/src/components/ItemCard.vue
+++ b/src/components/ItemCard.vue
@@ -46,6 +46,15 @@
         Price: ${{ item.price }}
       </p>
       <p class="text-gray-600 text-sm mb-1">
+        Quantity: {{ item.quantity }}
+      </p>
+      <p
+        v-if="item.skuCodes && item.skuCodes.length"
+        class="text-gray-600 text-sm mb-1"
+      >
+        SKU: {{ item.skuCodes.join(', ') }}
+      </p>
+      <p class="text-gray-600 text-sm mb-1">
         Location: {{ item.location }}
       </p>
       <p class="text-gray-500 text-xs mb-3">

--- a/src/components/ItemForm.vue
+++ b/src/components/ItemForm.vue
@@ -46,6 +46,26 @@
     </div>
 
     <div class="mb-4">
+      <label class="block text-gray-700 font-medium mb-2">Quantity</label>
+      <input
+        v-model.number="newItem.quantity"
+        type="number"
+        class="w-full px-3 py-2 border border-gray-300 rounded"
+        min="1"
+      >
+    </div>
+
+    <div class="mb-4">
+      <label class="block text-gray-700 font-medium mb-2">SKU Codes</label>
+      <input
+        v-model="skuInput"
+        type="text"
+        class="w-full px-3 py-2 border border-gray-300 rounded"
+        placeholder="ABC123, ABC124"
+      >
+    </div>
+
+    <div class="mb-4">
       <label class="block text-gray-700 font-medium mb-2">
         Image <span class="text-red-500">*</span>
       </label>
@@ -114,7 +134,7 @@
 
 <script setup lang="ts">
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { ref, computed } from 'vue';
+import { ref, computed, watch } from 'vue';
 import { statusOptions } from '../types/item';
 import type { Item } from '../types/item';
 import { mapRecordToItem } from '../types/item';
@@ -131,7 +151,9 @@ const newItem = ref({
   status: 'not_sold' as const,
   location: '',
   price: '',
-  feePercent: 20
+  feePercent: 20,
+  quantity: 1,
+  skuCodes: [] as string[]
 });
 
 const displayPrice = computed({
@@ -143,6 +165,11 @@ const displayPrice = computed({
 });
 const selectedFile = ref<File | null>(null);
 const previewUrl = ref<string>('');
+const skuInput = ref('');
+
+watch(skuInput, val => {
+  newItem.value.skuCodes = val.split(',').map(v => v.trim()).filter(Boolean);
+});
 
 const isFormValid = computed(() => {
   return !!(
@@ -151,7 +178,8 @@ const isFormValid = computed(() => {
     selectedFile.value &&
     newItem.value.location.trim() &&
     newItem.value.price.trim() &&
-    newItem.value.feePercent >= 0
+    newItem.value.feePercent >= 0 &&
+    newItem.value.quantity > 0
   );
 });
 
@@ -187,6 +215,8 @@ const handleSubmit = async () => {
         user_id: user?.id,
         name: newItem.value.name,
         details: newItem.value.details,
+        quantity: newItem.value.quantity,
+        sku_codes: newItem.value.skuCodes,
         status: newItem.value.status,
         location: newItem.value.location,
         price: newItem.value.price,
@@ -210,10 +240,13 @@ const handleSubmit = async () => {
       status: 'not_sold',
       location: '',
       price: '',
-      feePercent: 20
+      feePercent: 20,
+      quantity: 1,
+      skuCodes: []
     };
     selectedFile.value = null;
     previewUrl.value = '';
+    skuInput.value = '';
   } catch (err: any) {
     console.error(err);
     alert('❌ Error saving item: ' + err.message);

--- a/src/components/ItemRow.vue
+++ b/src/components/ItemRow.vue
@@ -37,6 +37,12 @@
       ${{ item.price }}
     </td>
     <td class="px-3 py-2 text-sm text-gray-600">
+      {{ item.quantity }}
+    </td>
+    <td class="px-3 py-2 text-sm text-gray-600">
+      <span v-if="item.skuCodes && item.skuCodes.length">{{ item.skuCodes.join(', ') }}</span>
+    </td>
+    <td class="px-3 py-2 text-sm text-gray-600">
       {{ item.location }}
     </td>
     <td class="px-3 py-2">

--- a/src/components/ItemTable.vue
+++ b/src/components/ItemTable.vue
@@ -24,6 +24,12 @@
           Price
         </th>
         <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          Qty
+        </th>
+        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          SKU
+        </th>
+        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Location
         </th>
         <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -5,6 +5,10 @@ export interface Item {
   name: string;
   imageUrl: string;
   details: string;
+  /** How many of this item exist */
+  quantity: number;
+  /** Optional list of SKU codes for individual units */
+  skuCodes: string[];
   status: "not_sold" | "sold" | "sold_paid";
   dateAdded: string;
   location: string;
@@ -34,12 +38,30 @@ export function mapRecordToItem(record: any): Item {
     }
   }
 
+  let skuCodes: string[] = [];
+  if (Array.isArray(record.sku_codes)) {
+    skuCodes = record.sku_codes;
+  } else if (typeof record.sku_codes === 'string') {
+    try {
+      const parsed = JSON.parse(record.sku_codes);
+      if (Array.isArray(parsed)) {
+        skuCodes = parsed;
+      } else if (parsed) {
+        skuCodes = String(parsed).split(',').map((s: string) => s.trim()).filter(Boolean);
+      }
+    } catch {
+      skuCodes = record.sku_codes.split(',').map((s: string) => s.trim()).filter(Boolean);
+    }
+  }
+
   return {
     id: record.id,
     userId: record.user_id,
     name: record.name,
     imageUrl: record.image_url ?? '',
     details: record.details,
+    quantity: typeof record.quantity === 'number' ? record.quantity : 1,
+    skuCodes,
     status: record.status,
     dateAdded: record.date_added,
     location: record.location,
@@ -59,6 +81,8 @@ export const defaultItems: Item[] = [
     name: "Vintage Camera",
     imageUrl: "https://ik.imagekit.io/mydwcapp/placeholder-image-1.jpg",
     details: "A vintage film camera from the 1970s in excellent condition.",
+    quantity: 1,
+    skuCodes: [],
     status: "not_sold",
     dateAdded: new Date().toISOString(),
     location: "New York, NY",
@@ -71,6 +95,8 @@ export const defaultItems: Item[] = [
     name: "Antique Chair",
     imageUrl: "https://ik.imagekit.io/mydwcapp/placeholder-image-1.jpg",
     details: "Hand-carved wooden chair from the early 1900s.",
+    quantity: 1,
+    skuCodes: [],
     status: "sold",
     dateAdded: new Date().toISOString(),
     location: "San Francisco, CA",


### PR DESCRIPTION
## Summary
- add migration script for quantity and SKU fields
- document running the script in the README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ee12816888320879a4e1d5cf77904