### PR TITLE
Add service worker to cache images

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ If you've already created the `items` table, run
 [docs/MIGRATION_ADD_QUANTITY_AND_SKU.sql](docs/MIGRATION_ADD_QUANTITY_AND_SKU.sql)
 to add the `quantity` and `sku_codes` columns.
 
+## Service Worker Caching
+
+Images fetched from Supabase storage are cached using a service worker located at `public/sw.js`. The worker is automatically registered in `src/main.ts` and serves cached images on subsequent visits.
+
 ## License
 
 MIT

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,25 @@
+const CACHE_NAME = 'image-cache-v1';
+
+self.addEventListener('fetch', event => {
+  const url = new URL(event.request.url);
+  if (
+    url.origin.includes('.supabase.co') &&
+    url.pathname.includes('/storage/v1/object/public/images')
+  ) {
+    event.respondWith(
+      caches.open(CACHE_NAME).then(cache =>
+        cache.match(event.request).then(cached => {
+          if (cached) {
+            return cached;
+          }
+          return fetch(event.request).then(response => {
+            if (response.status === 200) {
+              cache.put(event.request, response.clone());
+            }
+            return response;
+          });
+        })
+      )
+    );
+  }
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,3 +13,12 @@ const app = createApp(AppRoot);
 app.use(router);
 
 app.mount('#app');
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js').catch(err => {
+      console.error('Service worker registration failed:', err);
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- cache Supabase images via service worker
- register service worker in the app
- document new caching behavior in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686179eb8348832085c64a239c6ef057