### PR TITLE
Add CSS spinner for item form loading states

### DIFF
--- a/src/components/EditItemForm.vue
+++ b/src/components/EditItemForm.vue
@@ -154,16 +154,24 @@
     <div class="flex space-x-2">
       <button
         class="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded font-medium"
+        :disabled="loading"
         @click="handleSubmit"
       >
         Update Item
       </button>
       <button
         class="bg-gray-300 hover:bg-gray-400 text-gray-800 px-4 py-2 rounded font-medium"
+        :disabled="loading"
         @click="$emit('cancel')"
       >
         Cancel
       </button>
+    </div>
+    <div
+      v-if="loading"
+      class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50"
+    >
+      <div class="animate-spin rounded-full h-16 w-16 border-4 border-white border-t-transparent"></div>
     </div>
     <ImageCropper
       :src="cropperSrc"
@@ -213,6 +221,7 @@ const tagInput = ref('');
 const skuInput = ref(form.value.skuCodes.join(', '));
 const showCropper = ref(false);
 const cropperSrc = ref('');
+const loading = ref(false);
 
 watch(skuInput, val => {
   form.value.skuCodes = val.split(',').map(v => v.trim()).filter(Boolean);
@@ -284,6 +293,7 @@ function toISODate(input: string): string | null {
 }
 
 async function handleSubmit() {
+  loading.value = true;
   try {
     let imageUrl = props.item.imageUrl;
     if (selectedFile.value) {
@@ -332,6 +342,8 @@ async function handleSubmit() {
   } catch (err: any) {
     console.error(err);
     alert('❌ Error updating item: ' + err.message);
+  } finally {
+    loading.value = false;
   }
 }
 </script>

--- a/src/components/ItemForm.vue
+++ b/src/components/ItemForm.vue
@@ -123,17 +123,24 @@
     <div class="flex space-x-2">
       <button
         class="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded font-medium disabled:opacity-50"
-        :disabled="!isFormValid"
+        :disabled="!isFormValid || loading"
         @click="handleSubmit"
       >
         Save Item
       </button>
       <button
         class="bg-gray-300 hover:bg-gray-400 text-gray-800 px-4 py-2 rounded font-medium"
+        :disabled="loading"
         @click="$emit('cancel')"
       >
         Cancel
       </button>
+    </div>
+    <div
+      v-if="loading"
+      class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50"
+    >
+      <div class="animate-spin rounded-full h-16 w-16 border-4 border-white border-t-transparent"></div>
     </div>
     <ImageCropper
       :src="cropperSrc"
@@ -168,6 +175,8 @@ const newItem = ref({
   quantity: 1,
   skuCodes: [] as string[]
 });
+
+const loading = ref(false);
 
 const displayPrice = computed({
   get: () => (newItem.value.price ? `$${newItem.value.price}` : ''),
@@ -222,6 +231,7 @@ function onCropped(file: File) {
 const handleSubmit = async () => {
   if (!isFormValid.value || !selectedFile.value) return;
 
+  loading.value = true;
   try {
     const { data: userData } = await supabase.auth.getUser();
     const user = userData.user;
@@ -278,6 +288,8 @@ const handleSubmit = async () => {
   } catch (err: any) {
     console.error(err);
     alert('❌ Error saving item: ' + err.message);
+  } finally {
+    loading.value = false;
   }
 };
 </script>


### PR DESCRIPTION
## Summary
- remove binary `loading.gif`
- show a CSS-based spinner overlay while saving or editing items

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68629faff71c8320928ac2ab8e875234