### PR TITLE
Add outstanding totals & duplication with export feedback

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -109,10 +109,32 @@
         </select>
       </template>
       <button
-        class="ml-auto text-sm text-blue-500 hover:underline"
+        class="ml-auto flex items-center px-3 py-1 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:opacity-50"
+        :disabled="exporting"
         @click="handleExportPdf"
       >
-        Export PDF
+        <svg
+          v-if="exporting"
+          class="animate-spin h-4 w-4 mr-2 text-white"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+        >
+          <circle
+            class="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            stroke-width="4"
+          />
+          <path
+            class="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+          />
+        </svg>
+        <span>{{ exporting ? 'Exporting...' : 'Export PDF' }}</span>
       </button>
     </div>
 
@@ -148,6 +170,7 @@
         @delete-item="deleteItem"
         @edit-item="startEdit"
         @view-image="openImageViewer"
+        @duplicate-item="duplicateItem"
       />
       <ItemTable
         v-else
@@ -156,6 +179,7 @@
         @delete-item="deleteItem"
         @edit-item="startEdit"
         @view-image="openImageViewer"
+        @duplicate-item="duplicateItem"
       />
     </template>
     <ImageViewer
@@ -193,9 +217,10 @@ const columns = ref(2);
 const isLoading = ref(true);
 const serverError = ref('');
 const editingItem = ref<Item | null>(null);
-const currentStats = ref<Stats>({ items: 0, sold: 0, sold_paid: 0, sold_paid_total: 0 });
+const currentStats = ref<Stats>({ items: 0, sold: 0, sold_paid: 0, sold_paid_total: 0, sold_unpaid_total: 0 });
 const searchQuery = ref('');
 const selectedImage = ref<string | null>(null);
+const exporting = ref(false);
 
 async function signOut() {
   document.cookie = 'introShown=; path=/; max-age=0';
@@ -379,8 +404,48 @@ const deleteItem = (id: string) => {
   currentStats.value = calculateStats(items.value);
 };
 
+async function duplicateItem(item: Item) {
+  if (DEBUG) console.log('Duplicating item:', item.id);
+  try {
+    const { data: userData } = await supabase.auth.getUser();
+    const user = userData.user;
+    const { data: inserted, error } = await supabase
+      .from('items')
+      .insert([
+        {
+          user_id: user?.id,
+          name: item.name,
+          details: item.details,
+          quantity: item.quantity,
+          sku_codes: item.skuCodes,
+          status: 'not_sold',
+          location: item.location,
+          price: item.price,
+          fee_percent: item.feePercent,
+          image_url: item.imageUrl,
+          date_added: new Date().toISOString(),
+          tags: item.tags
+        }
+      ])
+      .select()
+      .single();
+    if (error) throw error;
+    const newItem: Item = mapRecordToItem(inserted);
+    items.value = [newItem, ...items.value];
+    currentStats.value = calculateStats(items.value);
+  } catch (err: any) {
+    console.error(err);
+    alert('❌ Error duplicating item: ' + err.message);
+  }
+}
+
 async function handleExportPdf() {
-  await exportItemsToPdf(items.value);
+  exporting.value = true;
+  try {
+    await exportItemsToPdf(items.value);
+  } finally {
+    exporting.value = false;
+  }
 }
 </script>
 

--- a/src/components/EditItemForm.vue
+++ b/src/components/EditItemForm.vue
@@ -171,7 +171,7 @@
       v-if="loading"
       class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50"
     >
-      <div class="animate-spin rounded-full h-16 w-16 border-4 border-white border-t-transparent"></div>
+      <div class="animate-spin rounded-full h-16 w-16 border-4 border-white border-t-transparent" />
     </div>
     <ImageCropper
       :src="cropperSrc"

--- a/src/components/ItemCard.vue
+++ b/src/components/ItemCard.vue
@@ -107,6 +107,12 @@
             Edit
           </button>
           <button
+            class="text-green-500 hover:text-green-700 text-sm font-medium"
+            @click="handleDuplicate"
+          >
+            Duplicate
+          </button>
+          <button
             class="text-red-500 hover:text-red-700 text-sm font-medium"
             @click="handleDelete"
           >
@@ -133,6 +139,7 @@ const emit = defineEmits<{
   'delete-item': [string]
   'edit-item': [Item]
   'view-image': [string]
+  'duplicate-item': [Item]
 }>()
 
 // Add image error handling
@@ -154,6 +161,10 @@ const handleDelete = () => {
 
 const handleEdit = () => {
   emit('edit-item', props.item);
+};
+
+const handleDuplicate = () => {
+  emit('duplicate-item', props.item);
 };
 
 const handleViewImage = () => {

--- a/src/components/ItemForm.vue
+++ b/src/components/ItemForm.vue
@@ -140,7 +140,7 @@
       v-if="loading"
       class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50"
     >
-      <div class="animate-spin rounded-full h-16 w-16 border-4 border-white border-t-transparent"></div>
+      <div class="animate-spin rounded-full h-16 w-16 border-4 border-white border-t-transparent" />
     </div>
     <ImageCropper
       :src="cropperSrc"

--- a/src/components/ItemGrid.vue
+++ b/src/components/ItemGrid.vue
@@ -19,6 +19,7 @@
       @delete-item="(id) => $emit('delete-item', id)"
       @edit-item="(item) => $emit('edit-item', item)"
       @view-image="(src) => $emit('view-image', src)"
+      @duplicate-item="(item) => $emit('duplicate-item', item)"
     />
   </div>
 </template>
@@ -51,6 +52,7 @@ defineEmits<{
   'delete-item': [string]
   'edit-item': [Item]
   'view-image': [string]
+  'duplicate-item': [Item]
 }>()
 </script>
 

--- a/src/components/ItemRow.vue
+++ b/src/components/ItemRow.vue
@@ -69,6 +69,12 @@
           Edit
         </button>
         <button
+          class="text-green-500 hover:text-green-700 text-sm font-medium"
+          @click="handleDuplicate"
+        >
+          Duplicate
+        </button>
+        <button
           class="text-red-500 hover:text-red-700 text-sm font-medium"
           @click="handleDelete"
         >
@@ -93,6 +99,7 @@ const emit = defineEmits<{
   'delete-item': [string]
   'edit-item': [Item]
   'view-image': [string]
+  'duplicate-item': [Item]
 }>()
 
 const imageError = ref(false)
@@ -113,6 +120,10 @@ function handleDelete() {
 
 function handleEdit() {
   emit('edit-item', props.item)
+}
+
+function handleDuplicate() {
+  emit('duplicate-item', props.item)
 }
 
 function handleViewImage() {

--- a/src/components/ItemTable.vue
+++ b/src/components/ItemTable.vue
@@ -49,6 +49,7 @@
         @delete-item="id => $emit('delete-item', id)"
         @edit-item="item => $emit('edit-item', item)"
         @view-image="src => $emit('view-image', src)"
+        @duplicate-item="item => $emit('duplicate-item', item)"
       />
     </tbody>
   </table>
@@ -65,6 +66,7 @@ defineEmits<{
   'delete-item': [string]
   'edit-item': [Item]
   'view-image': [string]
+  'duplicate-item': [Item]
 }>()
 </script>
 

--- a/src/components/StatsDisplay.vue
+++ b/src/components/StatsDisplay.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
+  <div class="grid grid-cols-2 sm:grid-cols-5 gap-4 mb-6">
     <!-- Items Card -->
     <div class="flex flex-col bg-white border border-gray-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
       <div class="p-4 md:p-5">
@@ -41,6 +41,21 @@
         <div class="mt-1 flex items-center gap-x-2">
           <h3 class="text-xl sm:text-2xl font-medium text-gray-800 dark:text-neutral-200">
             {{ props.stats.sold_paid }}
+          </h3>
+        </div>
+      </div>
+    </div>
+    <!-- Outstanding Card -->
+    <div class="flex flex-col bg-white border border-gray-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
+      <div class="p-4 md:p-5">
+        <div class="flex items-center gap-x-2">
+          <p class="text-xs uppercase text-gray-500 dark:text-neutral-500">
+            Outstanding
+          </p>
+        </div>
+        <div class="mt-1 flex items-center gap-x-2">
+          <h3 class="text-xl sm:text-2xl font-medium text-gray-800 dark:text-neutral-200">
+            ${{ props.stats.sold_unpaid_total.toFixed(2) }}
           </h3>
         </div>
       </div>

--- a/src/utils/exportPdf.ts
+++ b/src/utils/exportPdf.ts
@@ -46,7 +46,8 @@ export async function exportItemsToPdf(items: Item[]): Promise<void> {
       `Items: ${stats.items}`,
       `Sold: ${stats.sold}`,
       `Paid: ${stats.sold_paid}`,
-      `Paid Total: $${stats.sold_paid_total.toFixed(2)}`
+      `Paid Total: $${stats.sold_paid_total.toFixed(2)}`,
+      `Outstanding: $${stats.sold_unpaid_total.toFixed(2)}`
     ];
     lines.forEach((line, idx) => {
       doc.text(line, pageWidth - margin, 10 + idx * 4, { align: 'right' });

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -6,6 +6,7 @@ export interface Stats {
   sold: number;
   sold_paid: number;
   sold_paid_total: number;
+  sold_unpaid_total: number;
 }
 
 
@@ -41,7 +42,14 @@ export function calculateStats(items: Item[]): Stats {
     const net = isNaN(num) ? 0 : num * (1 - fee / 100);
     return sum + net;
   }, 0);
-  return { items: total, sold, sold_paid, sold_paid_total };
+  const soldUnpaidItems = items.filter(i => i.status === 'sold');
+  const sold_unpaid_total = soldUnpaidItems.reduce((sum, item) => {
+    const num = parseFloat(String(item.price).replace(/[^0-9.]/g, ''));
+    const fee = typeof item.feePercent === 'number' ? item.feePercent : 20;
+    const net = isNaN(num) ? 0 : num * (1 - fee / 100);
+    return sum + net;
+  }, 0);
+  return { items: total, sold, sold_paid, sold_paid_total, sold_unpaid_total };
 }
 
 
@@ -106,7 +114,8 @@ export async function fetchStats(): Promise<Stats | null> {
       items: parsed.items ?? 0,
       sold: parsed.sold ?? 0,
       sold_paid: parsed.sold_paid ?? 0,
-      sold_paid_total: parsed.sold_paid_total ?? 0
+      sold_paid_total: parsed.sold_paid_total ?? 0,
+      sold_unpaid_total: parsed.sold_unpaid_total ?? 0
     };
   } catch (err) {
     console.error('Error parsing stats:', err);


### PR DESCRIPTION
## Summary
- show outstanding total of sold but unpaid items
- add duplication option for listings
- provide export button loading spinner and styling

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687005c5f08c832098687eb6ab9a48ca