### PR TITLE
Fix StatsDisplay closing tags

### DIFF
--- a/src/components/StatsDisplay.vue
+++ b/src/components/StatsDisplay.vue
@@ -51,41 +51,40 @@
       class="flex flex-col bg-white border border-gray-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700 cursor-pointer"
       @click="toggleOutstanding"
     >
-
-    <!-- Outstanding Card -->
-    <div class="flex flex-col bg-white border border-gray-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
-      <div class="p-4 md:p-5">
-        <div class="flex items-center gap-x-2">
-          <p class="text-xs uppercase text-gray-500 dark:text-neutral-500">
-            Outstanding
-          </p>
-        </div>
-        <div class="mt-1 flex items-center gap-x-2">
-          <h3 class="text-xl sm:text-2xl font-medium text-gray-800 dark:text-neutral-200">
-            ${{ props.stats.sold_unpaid_total.toFixed(2) }}
-          </h3>
+      <!-- Outstanding Card -->
+      <div class="flex flex-col bg-white border border-gray-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
+        <div class="p-4 md:p-5">
+          <div class="flex items-center gap-x-2">
+            <p class="text-xs uppercase text-gray-500 dark:text-neutral-500">
+              Outstanding
+            </p>
+          </div>
+          <div class="mt-1 flex items-center gap-x-2">
+            <h3 class="text-xl sm:text-2xl font-medium text-gray-800 dark:text-neutral-200">
+              ${{ props.stats.sold_unpaid_total.toFixed(2) }}
+            </h3>
+          </div>
         </div>
       </div>
-    </div>
-    <!-- Paid Total Card -->
-    <div class="flex flex-col bg-white border border-gray-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
-
-      <div class="p-4 md:p-5">
-        <div class="flex items-center gap-x-2">
-          <p class="text-xs uppercase text-gray-500 dark:text-neutral-500">
-            {{ showOutstanding ? 'Outstanding' : 'Paid Total' }}
-          </p>
-        </div>
-        <div class="mt-1 flex items-center gap-x-2">
-          <h3 class="text-xl sm:text-2xl font-medium text-gray-800 dark:text-neutral-200">
-            $
-            {{
-              (showOutstanding
-                ? props.stats.sold_unpaid_total
-                : props.stats.sold_paid_total
-              ).toFixed(2)
-            }}
-          </h3>
+      <!-- Paid Total Card -->
+      <div class="flex flex-col bg-white border border-gray-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
+        <div class="p-4 md:p-5">
+          <div class="flex items-center gap-x-2">
+            <p class="text-xs uppercase text-gray-500 dark:text-neutral-500">
+              {{ showOutstanding ? 'Outstanding' : 'Paid Total' }}
+            </p>
+          </div>
+          <div class="mt-1 flex items-center gap-x-2">
+            <h3 class="text-xl sm:text-2xl font-medium text-gray-800 dark:text-neutral-200">
+              $
+              {{
+                (showOutstanding
+                  ? props.stats.sold_unpaid_total
+                  : props.stats.sold_paid_total
+                ).toFixed(2)
+              }}
+            </h3>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- fix missing closing tags in StatsDisplay.vue

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6870558dd6d48320b00b8637efbb333e