### PR TITLE
Fix duplicate script blocks

### DIFF
--- a/src/components/StatsDisplay.vue
+++ b/src/components/StatsDisplay.vue
@@ -49,9 +49,9 @@
     <!-- Paid/Outstanding Toggle Card -->
     <div
       class="flex flex-col bg-white border border-gray-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700 cursor-pointer"
-      @click="toggleOutstanding" >
-
-  <!-- Outstanding Card -->
+      @click="toggleOutstanding"
+    >
+      <!-- Outstanding Card -->
       <div class="flex flex-col bg-white border border-gray-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
         <div class="p-4 md:p-5">
           <div class="flex items-center gap-x-2">
@@ -66,7 +66,7 @@
           </div>
         </div>
       </div>
-  <!-- Paid Total Card -->
+      <!-- Paid Total Card -->
       <div class="flex flex-col bg-white border border-gray-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
         <div class="p-4 md:p-5">
           <div class="flex items-center gap-x-2">
@@ -111,22 +111,3 @@ const toggleOutstanding = () => {
 /* Basic styling */
 </style>
 
-<script setup lang="ts">
-
-import { ref } from 'vue';
-import type { Stats } from '../utils/stats';
-
-const props = defineProps<{
-  stats: Stats;
-}>();
-
-const showOutstanding = ref(false);
-const toggleOutstanding = () => {
-  showOutstanding.value = !showOutstanding.value;
-};
-
-</script>
-
-<style scoped>
-/* Basic styling */
-</style>


### PR DESCRIPTION
## Summary
- remove duplicate `<script setup>` blocks from `StatsDisplay.vue`

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6870684ef29c83208e196b751eab2371