### PR TITLE
Remove redundant outstanding card

### DIFF
--- a/src/components/StatsDisplay.vue
+++ b/src/components/StatsDisplay.vue
@@ -49,24 +49,9 @@
     <!-- Paid/Outstanding Toggle Card -->
     <div
       class="flex flex-col bg-white border border-gray-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700 cursor-pointer"
-      @click="toggleOutstanding" >
-
-  <!-- Outstanding Card -->
-      <div class="flex flex-col bg-white border border-gray-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
-        <div class="p-4 md:p-5">
-          <div class="flex items-center gap-x-2">
-            <p class="text-xs uppercase text-gray-500 dark:text-neutral-500">
-              Outstanding
-            </p>
-          </div>
-          <div class="mt-1 flex items-center gap-x-2">
-            <h3 class="text-xl sm:text-2xl font-medium text-gray-800 dark:text-neutral-200">
-              ${{ props.stats.sold_unpaid_total.toFixed(2) }}
-            </h3>
-          </div>
-        </div>
-      </div>
-  <!-- Paid Total Card -->
+      @click="toggleOutstanding"
+    >
+      <!-- Paid Total Card -->
       <div class="flex flex-col bg-white border border-gray-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
         <div class="p-4 md:p-5">
           <div class="flex items-center gap-x-2">
@@ -111,22 +96,3 @@ const toggleOutstanding = () => {
 /* Basic styling */
 </style>
 
-<script setup lang="ts">
-
-import { ref } from 'vue';
-import type { Stats } from '../utils/stats';
-
-const props = defineProps<{
-  stats: Stats;
-}>();
-
-const showOutstanding = ref(false);
-const toggleOutstanding = () => {
-  showOutstanding.value = !showOutstanding.value;
-};
-
-</script>
-
-<style scoped>
-/* Basic styling */
-</style>


### PR DESCRIPTION
## Summary
- remove outstanding total card so toggle covers both views

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870684ef29c83208e196b751eab2371