### PR TITLE
Add interactive chart slideshow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@supabase/supabase-js": "^2.49.8",
                 "@tailwindcss/postcss": "^4.1.10",
                 "chart.js": "^4.4.1",
+                "chartjs-plugin-zoom": "^2.2.0",
                 "cropperjs": "^1.6.2",
                 "jspdf": "^2.5.1",
                 "lodash": "^4.17.21",
@@ -1420,6 +1421,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/hammerjs": {
+            "version": "2.0.46",
+            "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+            "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+            "license": "MIT"
+        },
         "node_modules/@types/node": {
             "version": "18.19.100",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.100.tgz",
@@ -2276,6 +2283,19 @@
                 "pnpm": ">=7"
             }
         },
+        "node_modules/chartjs-plugin-zoom": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/chartjs-plugin-zoom/-/chartjs-plugin-zoom-2.2.0.tgz",
+            "integrity": "sha512-in6kcdiTlP6npIVLMd4zXZ08PDUXC52gZ4FAy5oyjk1zX3gKarXMAof7B9eFiisf9WOC3bh2saHg+J5WtLXZeA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hammerjs": "^2.0.45",
+                "hammerjs": "^2.0.8"
+            },
+            "peerDependencies": {
+                "chart.js": ">=3.2.0"
+            }
+        },
         "node_modules/chokidar": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -3080,6 +3100,15 @@
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/hammerjs": {
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
+            "integrity": "sha512-tSQXBXS/MWQOn/RKckawJ61vvsDpCom87JgxiYdGwHdOa0ht0vzUWDlfioofFCRU0L+6NGDt6XzbgoJvZkMeRQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.0"
+            }
         },
         "node_modules/has-flag": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "@supabase/supabase-js": "^2.49.8",
         "@tailwindcss/postcss": "^4.1.10",
         "chart.js": "^4.4.1",
+        "chartjs-plugin-zoom": "^2.2.0",
         "cropperjs": "^1.6.2",
         "jspdf": "^2.5.1",
         "lodash": "^4.17.21",

--- a/src/components/StatsChart.vue
+++ b/src/components/StatsChart.vue
@@ -1,24 +1,52 @@
 <template>
   <div class="mb-6">
+    <div class="flex justify-end mb-2 space-x-2">
+      <button
+        class="px-2 py-1 text-sm bg-gray-200 rounded"
+        @click="prevSlide"
+      >
+        Prev
+      </button>
+      <button
+        class="px-2 py-1 text-sm bg-gray-200 rounded"
+        @click="nextSlide"
+      >
+        Next
+      </button>
+    </div>
     <canvas ref="canvas" />
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, onMounted, watch } from 'vue';
-import { Chart, registerables } from 'chart.js';
+import { Chart, registerables, type ChartConfiguration } from 'chart.js';
+import zoomPlugin from 'chartjs-plugin-zoom';
 import type { Item } from '../types/item';
 import {
   calculatePeriodStats,
   calculatePeriodTotals,
+  calculateMonthlyRevenue,
+  calculateStatusDistribution,
   type PeriodStats,
-  type PeriodTotals
+  type PeriodTotals,
+  type MonthlyRevenue,
+  type StatusDistribution
 } from '../utils/stats';
 
 const props = defineProps<{ items: Item[] }>();
 
 const canvas = ref<HTMLCanvasElement | null>(null);
 let chart: Chart | null = null;
+const slide = ref(0);
+const totalSlides = 3;
+
+function nextSlide() {
+  slide.value = (slide.value + 1) % totalSlides;
+}
+function prevSlide() {
+  slide.value = (slide.value - 1 + totalSlides) % totalSlides;
+}
 
 interface ChartData {
   counts: number[];
@@ -44,53 +72,103 @@ function buildData(items: Item[]): ChartData {
   return { counts, totals };
 }
 
-function renderChart() {
-  if (!canvas.value) return;
-  const data = buildData(props.items);
-
-  if (chart) {
-    chart.data.datasets[0].data = data.counts;
-    chart.data.datasets[1].data = data.totals;
-    chart.update();
-    return;
+function buildSlideConfig(items: Item[]): ChartConfiguration {
+  if (slide.value === 0) {
+    const data = buildData(items);
+    return {
+      type: 'bar',
+      data: {
+        labels: ['30 days', '6 months', '1 year'],
+        datasets: [
+          {
+            label: 'Items Sold',
+            backgroundColor: '#60a5fa',
+            yAxisID: 'yCounts',
+            data: data.counts
+          },
+          {
+            label: 'Paid Total ($)',
+            backgroundColor: '#34d399',
+            yAxisID: 'yTotals',
+            data: data.totals
+          }
+        ]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+          yCounts: {
+            beginAtZero: true,
+            position: 'left',
+            ticks: { precision: 0 }
+          },
+          yTotals: {
+            beginAtZero: true,
+            position: 'right'
+          }
+        },
+        plugins: {
+          zoom: { zoom: { wheel: { enabled: true }, pinch: { enabled: true }, mode: 'x' }, pan: { enabled: true, mode: 'x' } }
+        }
+      }
+    } as ChartConfiguration;
+  } else if (slide.value === 1) {
+    const revenue: MonthlyRevenue = calculateMonthlyRevenue(items);
+    return {
+      type: 'line',
+      data: {
+        labels: revenue.labels,
+        datasets: [
+          {
+            label: 'Monthly Revenue',
+            backgroundColor: 'rgba(52, 211, 153, 0.5)',
+            borderColor: '#34d399',
+            fill: true,
+            data: revenue.totals
+          }
+        ]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          zoom: { zoom: { wheel: { enabled: true }, pinch: { enabled: true }, mode: 'x' }, pan: { enabled: true, mode: 'x' } }
+        }
+      }
+    } as ChartConfiguration;
   }
 
-  Chart.register(...registerables);
-  chart = new Chart(canvas.value, {
-    type: 'bar',
+  const dist: StatusDistribution = calculateStatusDistribution(items);
+  return {
+    type: 'pie',
     data: {
-      labels: ['30 days', '6 months', '1 year'],
+      labels: dist.labels,
       datasets: [
         {
-          label: 'Items Sold',
-          backgroundColor: '#60a5fa',
-          yAxisID: 'yCounts',
-          data: data.counts
-        },
-        {
-          label: 'Paid Total ($)',
-          backgroundColor: '#34d399',
-          yAxisID: 'yTotals',
-          data: data.totals
+          label: 'Status',
+          backgroundColor: ['#60a5fa', '#fbbf24', '#34d399'],
+          data: dist.counts
         }
       ]
     },
     options: {
       responsive: true,
-      maintainAspectRatio: false,
-      scales: {
-        yCounts: {
-          beginAtZero: true,
-          position: 'left',
-          ticks: { precision: 0 }
-        },
-        yTotals: {
-          beginAtZero: true,
-          position: 'right'
-        }
-      }
+      maintainAspectRatio: false
     }
-  });
+  } as ChartConfiguration;
+}
+
+function renderChart() {
+  if (!canvas.value) return;
+  const config = buildSlideConfig(props.items);
+
+  if (chart) {
+    chart.destroy();
+  } else {
+    Chart.register(...registerables, zoomPlugin);
+  }
+  chart = new Chart(canvas.value, config);
 }
 
 onMounted(() => {
@@ -98,7 +176,7 @@ onMounted(() => {
 });
 
 watch(
-  () => props.items,
+  [() => props.items, slide],
   () => {
     renderChart();
   },


### PR DESCRIPTION
## Summary
- install `chartjs-plugin-zoom`
- compute monthly revenue and status distribution helpers
- add slideshow of bar, line, and pie charts with zoom/pan support

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a750e3ad883209c050b0ae0321109