### PR TITLE
Improve focus when editing items

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -45,18 +45,31 @@
       {{ serverError }}
     </div>
     
-    <ItemForm
-      v-if="showForm && !editingItem"
-      @item-added="handleItemAdded"
-      @cancel="showForm = false"
+    <div
+      v-if="showForm || editingItem"
+      class="fixed inset-0 bg-black bg-opacity-20 backdrop-blur-sm z-40"
     />
 
-    <EditItemForm
+    <div
+      v-if="showForm && !editingItem"
+      class="relative z-50"
+    >
+      <ItemForm
+        @item-added="handleItemAdded"
+        @cancel="showForm = false"
+      />
+    </div>
+
+    <div
       v-if="editingItem"
-      :item="editingItem"
-      @item-updated="handleItemUpdated"
-      @cancel="editingItem = null"
-    />
+      class="relative z-50"
+    >
+      <EditItemForm
+        :item="editingItem"
+        @item-updated="handleItemUpdated"
+        @cancel="editingItem = null"
+      />
+    </div>
     
     <div
       v-if="!showForm"


### PR DESCRIPTION
## Summary
- blur the background when item forms are active
- overlay is lighter to avoid overly dark background

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687a71a400f883209674bda8573e0d29