### PR TITLE
Tailwind UI refresh

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,216 +1,218 @@
 <template>
-  <div class="max-w-4xl mx-auto p-4">
-    <div class="flex items-center justify-between mb-8">
-      <div class="flex items-center space-x-2 flex-1">
-        <img
-          src="https://ielukqallxtceqmobmvp.supabase.co/storage/v1/object/public/images//uglysmall.png"
-          alt="Artwork Tracker logo"
-          class="w-8 h-8 object-contain"
+  <div class="min-h-screen bg-gray-100 text-gray-900 font-sans">
+    <div class="max-w-4xl mx-auto p-4">
+      <div class="flex items-center justify-between mb-8">
+        <div class="flex items-center space-x-2 flex-1">
+          <img
+            src="https://ielukqallxtceqmobmvp.supabase.co/storage/v1/object/public/images//uglysmall.png"
+            alt="Artwork Tracker logo"
+            class="w-8 h-8 object-contain"
+          >
+          <h1 class="text-3xl font-bold">
+            Artwork Tracker
+          </h1>
+        </div>
+        <button
+          class="bg-red-500 text-white font-semibold px-4 py-2 rounded-md hover:bg-red-600 active:scale-95 transition"
+          @click="signOut"
         >
-        <h1 class="text-3xl font-bold">
-          Artwork Tracker
-        </h1>
+          Sign Out
+        </button>
       </div>
-      <button
-        class="bg-red-500 hover:bg-red-600 text-white text-sm px-3 py-1 rounded"
-        @click="signOut"
-      >
-        Sign Out
-      </button>
-    </div>
 
-    <StatsDisplay :stats="currentStats" />
+      <StatsDisplay :stats="currentStats" />
 
-    <div class="flex justify-end mb-2">
-      <button
-        class="bg-blue-500 hover:bg-blue-600 text-white text-sm px-3 py-1 rounded"
-        @click="showChart = !showChart"
-      >
-        {{ showChart ? 'Hide Chart' : 'Show Chart' }}
-      </button>
-    </div>
-
-    <div
-      v-if="showChart"
-      class="fixed inset-0 bg-black bg-opacity-40 backdrop-blur-sm z-40"
-    />
-
-    <div
-      v-if="showChart"
-     
-      class="relative z-50"
-    >
-      <StatsChart
-        :items="items"
-        @close="showChart = false"
-      />
-    </div>
-
-
-    
-    <!-- Show server error if any -->
-    <div
-      v-if="serverError"
-      class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4"
-    >
-      {{ serverError }}
-    </div>
-    
-    <div
-      v-if="showForm || editingItem"
-      class="fixed inset-0 bg-black bg-opacity-40 backdrop-blur-sm z-40"
-    />
-
-    <div
-      v-if="showForm && !editingItem"
-      class="relative z-50"
-    >
-      <ItemForm
-        @item-added="handleItemAdded"
-        @cancel="showForm = false"
-      />
-    </div>
-
-    <div
-      v-if="editingItem"
-      class="relative z-50"
-    >
-      <EditItemForm
-        :item="editingItem"
-        @item-updated="handleItemUpdated"
-        @cancel="editingItem = null"
-      />
-    </div>
-    
-    <div
-      v-if="!showForm"
-      class="mb-6"
-    >
-      <button
-        class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded font-medium"
-        @click="showForm = true"
-      >
-        Add New Item
-      </button>
-    </div>
-    
-    <div class="mb-4 flex flex-wrap items-center">
-      <label
-        for="view"
-        class="mr-2 text-sm text-gray-700"
-      >View:</label>
-      <select
-        id="view"
-        v-model="layout"
-        class="border border-gray-300 rounded px-2 py-1 text-sm"
-      >
-        <option value="grid">
-          Grid
-        </option>
-        <option value="table">
-          Table
-        </option>
-      </select>
-      <template v-if="layout === 'grid'">
-        <label
-          for="columns"
-          class="ml-4 mr-2 text-sm text-gray-700"
-        >Columns:</label>
-        <select
-          id="columns"
-          v-model.number="columns"
-          class="border border-gray-300 rounded px-2 py-1 text-sm"
+      <div class="flex justify-end mb-2">
+        <button
+          class="bg-gradient-to-r from-purple-600 to-pink-500 text-white font-semibold px-4 py-2 rounded-md shadow hover:opacity-90 active:scale-95 transition"
+          @click="showChart = !showChart"
         >
-          <option :value="1">
-            1 column
+          {{ showChart ? 'Hide Chart' : 'Show Chart' }}
+        </button>
+      </div>
+
+      <div
+        v-if="showChart"
+        class="fixed inset-0 bg-black bg-opacity-40 backdrop-blur-sm z-40"
+      />
+
+      <div
+        v-if="showChart"
+     
+        class="relative z-50"
+      >
+        <StatsChart
+          :items="items"
+          @close="showChart = false"
+        />
+      </div>
+
+
+    
+      <!-- Show server error if any -->
+      <div
+        v-if="serverError"
+        class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4"
+      >
+        {{ serverError }}
+      </div>
+    
+      <div
+        v-if="showForm || editingItem"
+        class="fixed inset-0 bg-black bg-opacity-40 backdrop-blur-sm z-40"
+      />
+
+      <div
+        v-if="showForm && !editingItem"
+        class="relative z-50"
+      >
+        <ItemForm
+          @item-added="handleItemAdded"
+          @cancel="showForm = false"
+        />
+      </div>
+
+      <div
+        v-if="editingItem"
+        class="relative z-50"
+      >
+        <EditItemForm
+          :item="editingItem"
+          @item-updated="handleItemUpdated"
+          @cancel="editingItem = null"
+        />
+      </div>
+    
+      <div
+        v-if="!showForm"
+        class="mb-6"
+      >
+        <button
+          class="bg-gradient-to-r from-purple-600 to-pink-500 text-white font-semibold px-4 py-2 rounded-md shadow hover:opacity-90 active:scale-95 transition"
+          @click="showForm = true"
+        >
+          Add New Item
+        </button>
+      </div>
+    
+      <div class="mb-4 flex flex-wrap items-center">
+        <label
+          for="view"
+          class="mr-2 text-sm text-gray-700"
+        >View:</label>
+        <select
+          id="view"
+          v-model="layout"
+          class="px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 text-sm"
+        >
+          <option value="grid">
+            Grid
           </option>
-          <option :value="2">
-            2 columns
-          </option>
-          <option :value="3">
-            3 columns
+          <option value="table">
+            Table
           </option>
         </select>
-      </template>
-      <button
-        class="ml-auto flex items-center px-3 py-1 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:opacity-50"
-        :disabled="exporting"
-        @click="handleExportPdf"
-      >
-        <svg
-          v-if="exporting"
-          class="animate-spin h-4 w-4 mr-2 text-white"
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
+        <template v-if="layout === 'grid'">
+          <label
+            for="columns"
+            class="ml-4 mr-2 text-sm text-gray-700"
+          >Columns:</label>
+          <select
+            id="columns"
+            v-model.number="columns"
+            class="px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 text-sm"
+          >
+            <option :value="1">
+              1 column
+            </option>
+            <option :value="2">
+              2 columns
+            </option>
+            <option :value="3">
+              3 columns
+            </option>
+          </select>
+        </template>
+        <button
+          class="ml-auto flex items-center bg-gradient-to-r from-purple-600 to-pink-500 text-white font-semibold px-4 py-2 rounded-md shadow hover:opacity-90 active:scale-95 transition disabled:opacity-50"
+          :disabled="exporting"
+          @click="handleExportPdf"
         >
-          <circle
-            class="opacity-25"
-            cx="12"
-            cy="12"
-            r="10"
-            stroke="currentColor"
-            stroke-width="4"
-          />
-          <path
-            class="opacity-75"
-            fill="currentColor"
-            d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
-          />
-        </svg>
-        <span>{{ exporting ? 'Exporting...' : 'Export PDF' }}</span>
-      </button>
-    </div>
+          <svg
+            v-if="exporting"
+            class="animate-spin h-4 w-4 mr-2 text-white"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <circle
+              class="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              stroke-width="4"
+            />
+            <path
+              class="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+            />
+          </svg>
+          <span>{{ exporting ? 'Exporting...' : 'Export PDF' }}</span>
+        </button>
+      </div>
 
-    <div class="mb-4 flex items-end space-x-2">
-      <input
-        v-model="searchQuery"
-        type="text"
-        placeholder="Search"
-        class="flex-1 border border-gray-300 rounded px-2 py-1"
-      >
-      <button
-        v-if="searchQuery"
-        class="border border-gray-300 rounded px-2 py-1 bg-gray-100"
-        @click="clearSearch"
-      >
-        Clear
-      </button>
-    </div>
+      <div class="mb-4 flex items-end space-x-2">
+        <input
+          v-model="searchQuery"
+          type="text"
+          placeholder="Search"
+          class="flex-1 px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+        >
+        <button
+          v-if="searchQuery"
+          class="border border-gray-300 rounded px-2 py-1 bg-gray-100"
+          @click="clearSearch"
+        >
+          Clear
+        </button>
+      </div>
 
-    <div
-      v-if="isLoading"
-      class="text-center py-8"
-    >
-      Loading items...
-    </div>
+      <div
+        v-if="isLoading"
+        class="text-center py-8"
+      >
+        Loading items...
+      </div>
     
-    <template v-else>
-      <ItemGrid
-        v-if="layout === 'grid'"
-        :items="filteredItems"
-        :columns="columns"
-        @update-status="updateItemStatus"
-        @delete-item="deleteItem"
-        @edit-item="startEdit"
-        @view-image="openImageViewer"
-        @duplicate-item="duplicateItem"
+      <template v-else>
+        <ItemGrid
+          v-if="layout === 'grid'"
+          :items="filteredItems"
+          :columns="columns"
+          @update-status="updateItemStatus"
+          @delete-item="deleteItem"
+          @edit-item="startEdit"
+          @view-image="openImageViewer"
+          @duplicate-item="duplicateItem"
+        />
+        <ItemTable
+          v-else
+          :items="filteredItems"
+          @update-status="updateItemStatus"
+          @delete-item="deleteItem"
+          @edit-item="startEdit"
+          @view-image="openImageViewer"
+          @duplicate-item="duplicateItem"
+        />
+      </template>
+      <ImageViewer
+        v-if="selectedImage"
+        :src="selectedImage"
+        @close="selectedImage = null"
       />
-      <ItemTable
-        v-else
-        :items="filteredItems"
-        @update-status="updateItemStatus"
-        @delete-item="deleteItem"
-        @edit-item="startEdit"
-        @view-image="openImageViewer"
-        @duplicate-item="duplicateItem"
-      />
-    </template>
-    <ImageViewer
-      v-if="selectedImage"
-      :src="selectedImage"
-      @close="selectedImage = null"
-    />
+    </div>
   </div>
 </template>
 

--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -3,7 +3,7 @@
     ref="inputRef"
     type="date"
     :placeholder="placeholder"
-    class="w-full px-3 py-2 border border-gray-300 rounded"
+    class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
     @input="onInput"
     @change="onChange"
   >

--- a/src/components/EditItemForm.vue
+++ b/src/components/EditItemForm.vue
@@ -9,7 +9,7 @@
       <input
         v-model="form.name"
         type="text"
-        class="w-full px-3 py-2 border border-gray-300 rounded"
+        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 mb-4"
         placeholder="Enter item name"
       >
     </div>
@@ -19,7 +19,7 @@
       <input
         v-model="form.location"
         type="text"
-        class="w-full px-3 py-2 border border-gray-300 rounded"
+        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 mb-4"
         placeholder="Enter item location"
       >
     </div>
@@ -29,7 +29,7 @@
       <input
         v-model="displayPrice"
         type="text"
-        class="w-full px-3 py-2 border border-gray-300 rounded"
+        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 mb-4"
         placeholder="Enter item price"
       >
     </div>
@@ -39,7 +39,7 @@
       <input
         v-model.number="form.feePercent"
         type="number"
-        class="w-full px-3 py-2 border border-gray-300 rounded"
+        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 mb-4"
         min="0"
         step="0.1"
       >
@@ -50,7 +50,7 @@
       <input
         v-model.number="form.quantity"
         type="number"
-        class="w-full px-3 py-2 border border-gray-300 rounded"
+        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 mb-4"
         min="1"
       >
     </div>
@@ -60,7 +60,7 @@
       <input
         v-model="skuInput"
         type="text"
-        class="w-full px-3 py-2 border border-gray-300 rounded"
+        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 mb-4"
         placeholder="ABC123, ABC124"
       >
     </div>
@@ -78,7 +78,7 @@
       <input
         type="file"
         accept="image/*"
-        class="w-full px-3 py-2 border border-gray-300 rounded"
+        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 mb-4"
         @change="onFileChange"
       >
       <div
@@ -103,7 +103,7 @@
       <label class="block text-gray-700 font-medium mb-2">Item Details</label>
       <textarea
         v-model="form.details"
-        class="w-full px-3 py-2 border border-gray-300 rounded"
+        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 mb-4"
         rows="3"
         placeholder="Enter item details"
       />
@@ -113,7 +113,7 @@
       <label class="block text-gray-700 font-medium mb-2">Status</label>
       <select
         v-model="form.status"
-        class="w-full px-3 py-2 border border-gray-300 rounded"
+        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 mb-4"
       >
         <option
           v-for="option in statusOptions"
@@ -145,7 +145,7 @@
       <input
         v-model="tagInput"
         type="text"
-        class="w-full px-3 py-2 border border-gray-300 rounded"
+        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 mb-4"
         placeholder="Add tag and press Enter"
         @keyup.enter.prevent="addTag"
       >

--- a/src/components/ItemCard.vue
+++ b/src/components/ItemCard.vue
@@ -78,7 +78,7 @@
         <label class="block text-sm font-medium text-gray-700 mb-1">Status:</label>
         <select
           :value="item.status"
-          class="w-full px-3 py-2 border border-gray-300 rounded text-sm"
+          class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 text-sm"
           @change="handleStatusChange"
         >
           <option 

--- a/src/components/ItemForm.vue
+++ b/src/components/ItemForm.vue
@@ -9,7 +9,7 @@
       <input
         v-model="newItem.name"
         type="text"
-        class="w-full px-3 py-2 border border-gray-300 rounded"
+        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 mb-4"
         placeholder="Enter item name"
       >
     </div>
@@ -19,7 +19,7 @@
       <input
         v-model="newItem.location"
         type="text"
-        class="w-full px-3 py-2 border border-gray-300 rounded"
+        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 mb-4"
         placeholder="Enter item location"
       >
     </div>
@@ -29,7 +29,7 @@
       <input
         v-model="displayPrice"
         type="text"
-        class="w-full px-3 py-2 border border-gray-300 rounded"
+        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 mb-4"
         placeholder="Enter item price"
       >
     </div>
@@ -39,7 +39,7 @@
       <input
         v-model.number="newItem.feePercent"
         type="number"
-        class="w-full px-3 py-2 border border-gray-300 rounded"
+        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 mb-4"
         min="0"
         step="0.1"
       >
@@ -50,7 +50,7 @@
       <input
         v-model.number="newItem.quantity"
         type="number"
-        class="w-full px-3 py-2 border border-gray-300 rounded"
+        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 mb-4"
         min="1"
       >
     </div>
@@ -60,7 +60,7 @@
       <input
         v-model="skuInput"
         type="text"
-        class="w-full px-3 py-2 border border-gray-300 rounded"
+        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 mb-4"
         placeholder="ABC123, ABC124"
       >
     </div>
@@ -72,7 +72,7 @@
       <input
         type="file"
         accept="image/*"
-        class="w-full px-3 py-2 border border-gray-300 rounded"
+        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 mb-4"
         required
         @change="onFileChange"
       >
@@ -98,7 +98,7 @@
       <label class="block text-gray-700 font-medium mb-2">Item Details</label>
       <textarea
         v-model="newItem.details"
-        class="w-full px-3 py-2 border border-gray-300 rounded"
+        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 mb-4"
         rows="3"
         placeholder="Enter item details"
       />
@@ -108,7 +108,7 @@
       <label class="block text-gray-700 font-medium mb-2">Status</label>
       <select
         v-model="newItem.status"
-        class="w-full px-3 py-2 border border-gray-300 rounded"
+        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 mb-4"
       >
         <option
           v-for="option in statusOptions"

--- a/src/components/ItemRow.vue
+++ b/src/components/ItemRow.vue
@@ -48,7 +48,7 @@
     <td class="px-3 py-2">
       <select
         :value="item.status"
-        class="border border-gray-300 rounded px-2 py-1 text-sm"
+        class="px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 text-sm"
         @change="handleStatusChange"
       >
         <option

--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -22,7 +22,7 @@
         type="email"
         placeholder="Email"
         required
-        class="border w-full px-3 py-2 rounded"
+        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 mb-4"
       >
       <div>
         <input
@@ -31,7 +31,7 @@
           type="password"
           placeholder="Password"
           required
-          class="border w-full px-3 py-2 rounded"
+          class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 mb-4"
         >
         <div class="flex items-center mt-2">
           <input

--- a/src/components/StatsChart.vue
+++ b/src/components/StatsChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="chart-container bg-white p-4 rounded-lg shadow-md relative">
+  <div class="chart-container bg-white p-4 rounded-xl shadow-lg max-w-xl mx-auto relative">
     <button
       class="absolute top-0 right-0 m-2 text-gray-500"
       aria-label="Close"
@@ -9,13 +9,13 @@
     </button>
     <div class="flex justify-end mb-2 space-x-2">
       <button
-        class="px-2 py-1 text-sm bg-gray-200 rounded"
+        class="bg-gray-200 text-gray-700 px-3 py-1 rounded hover:bg-gray-300 active:scale-95"
         @click="prevSlide"
       >
         Prev
       </button>
       <button
-        class="px-2 py-1 text-sm bg-gray-200 rounded"
+        class="bg-gray-200 text-gray-700 px-3 py-1 rounded hover:bg-gray-300 active:scale-95"
         @click="nextSlide"
       >
         Next

--- a/src/components/StatsDisplay.vue
+++ b/src/components/StatsDisplay.vue
@@ -1,80 +1,50 @@
 <template>
   <div class="grid grid-cols-2 sm:grid-cols-5 gap-4 mb-6">
-    <!-- Items Card -->
-    <div class="flex flex-col bg-white border border-gray-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
-      <div class="p-4 md:p-5">
-        <div class="flex items-center gap-x-2">
-          <p class="text-xs uppercase text-gray-500 dark:text-neutral-500">
-            Items
-          </p>
-        </div>
-        <div class="mt-1 flex items-center gap-x-2">
-          <h3 class="text-xl sm:text-2xl font-medium text-gray-800 dark:text-neutral-200">
-            {{ props.stats.items }}
-          </h3>
-        </div>
-      </div>
+    <div class="bg-white rounded-xl shadow-md p-4 text-center">
+      <h2 class="text-sm text-gray-500 uppercase">
+        Items
+      </h2>
+      <p class="text-2xl font-semibold text-gray-800">
+        {{ props.stats.items }}
+      </p>
     </div>
-    <!-- Sold Card -->
-    <div class="flex flex-col bg-white border border-gray-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
-      <div class="p-4 md:p-5">
-        <div class="flex items-center gap-x-2">
-          <p class="text-xs uppercase text-gray-500 dark:text-neutral-500">
-            Sold
-          </p>
-        </div>
-        <div class="mt-1 flex items-center gap-x-2">
-          <h3 class="text-xl sm:text-2xl font-medium text-gray-800 dark:text-neutral-200">
-            {{ props.stats.sold }}
-          </h3>
-        </div>
-      </div>
+    <div class="bg-white rounded-xl shadow-md p-4 text-center">
+      <h2 class="text-sm text-gray-500 uppercase">
+        Sold
+      </h2>
+      <p class="text-2xl font-semibold text-gray-800">
+        {{ props.stats.sold }}
+      </p>
     </div>
-    <!-- Paid Card -->
-    <div class="flex flex-col bg-white border border-gray-200 shadow-2xs rounded-xl dark:bg-neutral-800 dark:border-neutral-700">
-      <div class="p-4 md:p-5">
-        <div class="flex items-center gap-x-2">
-          <p class="text-xs uppercase text-gray-500 dark:text-neutral-500">
-            Paid
-          </p>
-        </div>
-        <div class="mt-1 flex items-center gap-x-2">
-          <h3 class="text-xl sm:text-2xl font-medium text-gray-800 dark:text-neutral-200">
-            {{ props.stats.sold_paid }}
-          </h3>
-        </div>
-      </div>
+    <div class="bg-white rounded-xl shadow-md p-4 text-center">
+      <h2 class="text-sm text-gray-500 uppercase">
+        Paid
+      </h2>
+      <p class="text-2xl font-semibold text-gray-800">
+        {{ props.stats.sold_paid }}
+      </p>
     </div>
-
-    <!-- Paid/Outstanding Toggle Card -->
     <div
-      class="flex flex-col bg-gradient-to-br from-blue-400 to-purple-500 text-white shadow-2xs rounded-xl border border-blue-400 dark:from-blue-500 dark:to-purple-600 dark:border-blue-500 cursor-pointer"
+      class="bg-gradient-to-r from-purple-600 to-pink-500 rounded-xl text-white shadow-md p-4 text-center cursor-pointer"
       @click="toggleOutstanding"
     >
-      <div class="p-4 md:p-5">
-        <div class="flex items-center gap-x-2">
-          <p class="text-xs uppercase opacity-90">
-            {{ showOutstanding ? 'Outstanding' : 'Paid Total' }}
-          </p>
-        </div>
-        <div class="mt-1 flex items-center gap-x-2">
-          <h3 class="text-xl sm:text-2xl font-medium">
-            $
-            {{
-              (showOutstanding
-                ? props.stats.sold_unpaid_total
-                : props.stats.sold_paid_total
-              ).toFixed(2)
-            }}
-          </h3>
-        </div>
-      </div>
+      <h2 class="text-sm uppercase">
+        {{ showOutstanding ? 'Outstanding' : 'Paid Total' }}
+      </h2>
+      <p class="text-2xl font-bold">
+        $
+        {{
+          (showOutstanding
+            ? props.stats.sold_unpaid_total
+            : props.stats.sold_paid_total
+          ).toFixed(2)
+        }}
+      </p>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-
 import { ref } from 'vue';
 import type { Stats } from '../utils/stats';
 
@@ -86,10 +56,8 @@ const showOutstanding = ref(false);
 const toggleOutstanding = () => {
   showOutstanding.value = !showOutstanding.value;
 };
-
 </script>
 
 <style scoped>
 /* Basic styling */
 </style>
-

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,6 +9,9 @@ export default {
     './src/assets/**/*.css'
   ],
   theme: {
+    fontFamily: {
+      sans: ['Inter', 'sans-serif']
+    },
     extend: {
       spacing: {
         10.5: '2.625rem',


### PR DESCRIPTION
## Summary
- add Inter as default font family in Tailwind
- wrap the app in a global Tailwind layout container
- update stats display cards with new gradient card style
- tweak chart modal container and navigation buttons
- style forms, inputs and selects using Tailwind components

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687c63595ab083209e7ceaa8cc7a46f7