### PR TITLE
Improve focus when editing items

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -45,18 +45,31 @@
       {{ serverError }}
     </div>
     
-    <ItemForm
-      v-if="showForm && !editingItem"
-      @item-added="handleItemAdded"
-      @cancel="showForm = false"
+    <div
+      v-if="showForm || editingItem"
+      class="fixed inset-0 bg-black/20 backdrop-blur-sm z-40"
     />
 
-    <EditItemForm
+    <div
+      v-if="showForm && !editingItem"
+      class="fixed inset-0 z-50 overflow-y-auto flex items-start justify-center mt-4 p-2"
+    >
+      <ItemForm
+        @item-added="handleItemAdded"
+        @cancel="showForm = false"
+      />
+    </div>
+
+    <div
       v-if="editingItem"
-      :item="editingItem"
-      @item-updated="handleItemUpdated"
-      @cancel="editingItem = null"
-    />
+      class="fixed inset-0 z-50 overflow-y-auto flex items-start justify-center mt-4 p-2"
+    >
+      <EditItemForm
+        :item="editingItem"
+        @item-updated="handleItemUpdated"
+        @cancel="editingItem = null"
+      />
+    </div>
     
     <div
       v-if="!showForm"

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -8,7 +8,7 @@
 
 
 body {
-  @apply bg-gray-100 text-gray-800;
+  @apply bg-gray-100 text-gray-800 overflow-x-hidden;
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
## Summary
- blur the background when item forms are active with lighter overlay
- keep forms fixed near the top on mobile
- prevent horizontal scrolling on mobile

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687a71a400f883209674bda8573e0d29