### PR TITLE
Improve edit item modal styles

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -59,7 +59,7 @@
     
       <div
         v-if="showForm || editingItem"
-        class="fixed inset-0 bg-black bg-opacity-40 backdrop-blur-sm z-40"
+        class="fixed inset-0 bg-black/30 backdrop-blur-sm z-40"
       />
 
       <div

--- a/src/components/EditItemForm.vue
+++ b/src/components/EditItemForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="max-w-xl mx-auto bg-white p-6 rounded-xl shadow-md">
+  <div class="relative z-50 bg-white p-6 rounded-xl shadow-xl max-w-md mx-auto mt-10">
     <h2 class="text-xl font-semibold mb-4">
       Edit Item
     </h2>
@@ -9,7 +9,7 @@
       <input
         v-model="form.name"
         type="text"
-        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
         placeholder="Enter item name"
       >
     </div>
@@ -19,7 +19,7 @@
       <input
         v-model="form.location"
         type="text"
-        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
         placeholder="Enter item location"
       >
     </div>
@@ -29,7 +29,7 @@
       <input
         v-model="displayPrice"
         type="text"
-        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
         placeholder="Enter item price"
       >
     </div>
@@ -39,7 +39,7 @@
       <input
         v-model.number="form.feePercent"
         type="number"
-        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
         min="0"
         step="0.1"
       >
@@ -50,7 +50,7 @@
       <input
         v-model.number="form.quantity"
         type="number"
-        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
         min="1"
       >
     </div>
@@ -60,7 +60,7 @@
       <input
         v-model="skuInput"
         type="text"
-        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
         placeholder="ABC123, ABC124"
       >
     </div>
@@ -78,7 +78,7 @@
       <input
         type="file"
         accept="image/*"
-        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
         @change="onFileChange"
       >
       <div
@@ -103,7 +103,7 @@
       <label class="block text-sm font-medium text-gray-700 mb-1">Item Details</label>
       <textarea
         v-model="form.details"
-        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
         rows="3"
         placeholder="Enter item details"
       />
@@ -113,7 +113,7 @@
       <label class="block text-sm font-medium text-gray-700 mb-1">Status</label>
       <select
         v-model="form.status"
-        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
       >
         <option
           v-for="option in statusOptions"
@@ -145,22 +145,22 @@
       <input
         v-model="tagInput"
         type="text"
-        class="w-full px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
         placeholder="Add tag and press Enter"
         @keyup.enter.prevent="addTag"
       >
     </div>
 
-    <div class="flex space-x-2">
+    <div class="flex gap-3 mt-4">
       <button
-        class="mt-4 bg-gradient-to-r from-purple-600 to-pink-500 text-white font-semibold px-6 py-2 rounded-md shadow hover:opacity-90 active:scale-95 transition disabled:opacity-50"
+        class="bg-gradient-to-r from-purple-600 to-pink-500 text-white font-semibold px-4 py-2 rounded-md shadow hover:opacity-90 active:scale-95 transition w-full disabled:opacity-50"
         :disabled="loading"
         @click="handleSubmit"
       >
         Update Item
       </button>
       <button
-        class="bg-gray-300 hover:bg-gray-400 text-gray-800 px-4 py-2 rounded font-medium"
+        class="bg-gray-200 text-gray-800 font-semibold px-4 py-2 rounded-md hover:bg-gray-300 transition w-full"
         :disabled="loading"
         @click="$emit('cancel')"
       >


### PR DESCRIPTION
## Summary
- update modal backdrop style
- tweak EditItemForm container and inputs
- align Update/Cancel buttons with Tailwind

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687ce1f85578832084b78268e9af52a3