### PR TITLE
Fix table layout overflow

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-h-screen bg-gray-100 text-gray-900 font-sans">
-    <div class="max-w-4xl mx-auto p-4">
+    <div class="flex flex-col gap-6 px-4 py-6 max-w-screen-xl mx-auto overflow-y-auto">
       <div class="flex items-center justify-between mb-8">
         <div class="flex items-center space-x-2 flex-1">
           <img

--- a/src/components/ItemRow.vue
+++ b/src/components/ItemRow.vue
@@ -1,6 +1,6 @@
 <template>
   <tr>
-    <td class="px-3 py-2">
+    <td class="px-4 py-3 whitespace-nowrap">
       <div class="relative w-12 h-12">
         <img
           v-if="item.imageUrl"
@@ -22,7 +22,7 @@
         >Local</span>
       </div>
     </td>
-    <td class="px-3 py-2">
+    <td class="px-4 py-3 whitespace-nowrap">
       <div class="font-semibold">
         {{ item.name }}
       </div>
@@ -30,22 +30,22 @@
         {{ formattedDate }}
       </div>
     </td>
-    <td class="px-3 py-2 text-sm text-gray-600">
+    <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-600">
       {{ item.details }}
     </td>
-    <td class="px-3 py-2 text-sm text-gray-600">
+    <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-600">
       ${{ item.price }}
     </td>
-    <td class="px-3 py-2 text-sm text-gray-600">
+    <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-600">
       {{ item.quantity }}
     </td>
-    <td class="px-3 py-2 text-sm text-gray-600">
+    <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-600">
       <span v-if="item.skuCodes && item.skuCodes.length">{{ item.skuCodes.join(', ') }}</span>
     </td>
-    <td class="px-3 py-2 text-sm text-gray-600">
+    <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-600">
       {{ item.location }}
     </td>
-    <td class="px-3 py-2">
+    <td class="px-4 py-3 whitespace-nowrap">
       <select
         :value="item.status"
         class="px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 text-sm"
@@ -60,7 +60,7 @@
         </option>
       </select>
     </td>
-    <td class="px-3 py-2">
+    <td class="px-4 py-3 whitespace-nowrap">
       <div class="flex space-x-2">
         <button
           class="text-blue-500 hover:text-blue-700 text-sm font-medium"

--- a/src/components/ItemTable.vue
+++ b/src/components/ItemTable.vue
@@ -5,54 +5,56 @@
   >
     No items added yet. Click "Add New Item" to get started.
   </div>
-  <table
+  <div
     v-else
-    class="min-w-full divide-y divide-gray-200"
+    class="overflow-x-auto w-full"
   >
-    <thead class="bg-gray-50">
-      <tr>
-        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-          Image
-        </th>
-        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-          Name
-        </th>
-        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-          Details
-        </th>
-        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-          Price
-        </th>
-        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-          Qty
-        </th>
-        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-          SKU
-        </th>
-        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-          Location
-        </th>
-        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-          Status
-        </th>
-        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-          Actions
-        </th>
-      </tr>
-    </thead>
-    <tbody class="bg-white divide-y divide-gray-200">
-      <ItemRow
-        v-for="item in items"
-        :key="item.id"
-        :item="item"
-        @update-status="(id, s) => $emit('update-status', id, s)"
-        @delete-item="id => $emit('delete-item', id)"
-        @edit-item="item => $emit('edit-item', item)"
-        @view-image="src => $emit('view-image', src)"
-        @duplicate-item="item => $emit('duplicate-item', item)"
-      />
-    </tbody>
-  </table>
+    <table class="min-w-full table-auto text-sm text-left divide-y divide-gray-200">
+      <thead class="bg-gray-50 sticky top-0 z-10 shadow-sm">
+        <tr>
+          <th class="px-4 py-3 whitespace-nowrap text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+            Image
+          </th>
+          <th class="px-4 py-3 whitespace-nowrap text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+            Name
+          </th>
+          <th class="px-4 py-3 whitespace-nowrap text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+            Details
+          </th>
+          <th class="px-4 py-3 whitespace-nowrap text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+            Price
+          </th>
+          <th class="px-4 py-3 whitespace-nowrap text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+            Qty
+          </th>
+          <th class="px-4 py-3 whitespace-nowrap text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+            SKU
+          </th>
+          <th class="px-4 py-3 whitespace-nowrap text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+            Location
+          </th>
+          <th class="px-4 py-3 whitespace-nowrap text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+            Status
+          </th>
+          <th class="px-4 py-3 whitespace-nowrap text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+            Actions
+          </th>
+        </tr>
+      </thead>
+      <tbody class="bg-white divide-y divide-gray-200">
+        <ItemRow
+          v-for="item in items"
+          :key="item.id"
+          :item="item"
+          @update-status="(id, s) => $emit('update-status', id, s)"
+          @delete-item="id => $emit('delete-item', id)"
+          @edit-item="item => $emit('edit-item', item)"
+          @view-image="src => $emit('view-image', src)"
+          @duplicate-item="item => $emit('duplicate-item', item)"
+        />
+      </tbody>
+    </table>
+  </div>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
## Summary
- keep stats area and table scrollable
- add responsive container to the table
- tighten table cell spacing

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687cecb9d45c832095269e3847ee9ebf