### PR TITLE
Add restock alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A single-page application built with Vue 3 and TypeScript for tracking items wit
 
 - Add items with images, names, prices, locations, and detailed descriptions
 - Specify a quantity and optional SKU codes for each item
+- Set a restock alert level to flag low stock
 - Set a custom shop fee percentage for each item (defaults to 20%)
 - Track item sales status (Not Sold / Sold / Paid)
 - Simple per-user statistics for Sold and Paid counts stored in Supabase, updated automatically when items change
@@ -114,6 +115,7 @@ required table, policies, and storage buckets.
 If you've already created the `items` table, run
 [docs/MIGRATION_ADD_QUANTITY_AND_SKU.sql](docs/MIGRATION_ADD_QUANTITY_AND_SKU.sql)
 to add the `quantity` and `sku_codes` columns.
+Run [docs/MIGRATION_ADD_MIN_QUANTITY.sql](docs/MIGRATION_ADD_MIN_QUANTITY.sql) to add `min_quantity` for restock alerts.
 
 ## Service Worker Caching
 

--- a/docs/MIGRATION_ADD_MIN_QUANTITY.sql
+++ b/docs/MIGRATION_ADD_MIN_QUANTITY.sql
@@ -1,0 +1,5 @@
+-- Migration script to add min_quantity column for restock alerts
+-- Run this against an existing Supabase project.
+
+alter table if exists public.items
+  add column if not exists min_quantity integer default 0;

--- a/src/App.vue
+++ b/src/App.vue
@@ -22,6 +22,13 @@
 
       <StatsDisplay :stats="currentStats" />
 
+      <div
+        v-if="lowStockItems.length"
+        class="bg-yellow-100 text-yellow-800 px-4 py-2 rounded mb-4"
+      >
+        ⚠️ {{ lowStockItems.length }} item(s) need restocking
+      </div>
+
       <div class="flex justify-end mb-2">
         <button
           class="bg-gradient-to-r from-purple-600 to-pink-500 text-white font-semibold px-4 py-2 rounded-md shadow hover:opacity-90 active:scale-95 transition"
@@ -266,6 +273,10 @@ const filteredItems = computed(() => {
   }
   return results;
 });
+
+const lowStockItems = computed(() =>
+  items.value.filter(i => i.quantity < i.minQuantity)
+);
 
 
 

--- a/src/components/EditItemForm.vue
+++ b/src/components/EditItemForm.vue
@@ -56,6 +56,20 @@
     </div>
 
     <div class="mb-4">
+      <label
+        class="block text-sm font-medium text-gray-700 mb-1"
+        for="edit_min_quantity"
+      >Restock Alert Level</label>
+      <input
+        id="edit_min_quantity"
+        v-model.number="form.minQuantity"
+        type="number"
+        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
+        min="0"
+      >
+    </div>
+
+    <div class="mb-4">
       <label class="block text-sm font-medium text-gray-700 mb-1">SKU Codes</label>
       <input
         v-model="skuInput"
@@ -202,6 +216,7 @@ const form = ref({
   price: props.item.price,
   feePercent: props.item.feePercent ?? 20,
   quantity: props.item.quantity,
+  minQuantity: props.item.minQuantity,
   skuCodes: [...(props.item.skuCodes || [])],
   dateAdded: props.item.dateAdded.slice(0, 10),
   tags: [...(props.item.tags || [])]
@@ -238,6 +253,7 @@ watch(
       price: val.price,
       feePercent: val.feePercent ?? 20,
       quantity: val.quantity,
+      minQuantity: val.minQuantity,
       skuCodes: [...(val.skuCodes || [])],
       dateAdded: val.dateAdded.slice(0, 10),
       tags: [...(val.tags || [])]
@@ -324,6 +340,7 @@ async function handleSubmit() {
         location: form.value.location,
         price: form.value.price,
         quantity: form.value.quantity,
+        min_quantity: form.value.minQuantity,
         sku_codes: form.value.skuCodes,
         fee_percent: form.value.feePercent,
         image_url: imageUrl,

--- a/src/components/ItemCard.vue
+++ b/src/components/ItemCard.vue
@@ -47,6 +47,11 @@
       </p>
       <p class="text-sm text-gray-500 mb-1">
         Quantity: {{ item.quantity }}
+        <span
+          v-if="item.quantity < item.minQuantity"
+          class="text-red-600 ml-1"
+          title="Needs restock"
+        >⚠️</span>
       </p>
       <p
         v-if="item.skuCodes && item.skuCodes.length"

--- a/src/components/ItemForm.vue
+++ b/src/components/ItemForm.vue
@@ -56,6 +56,20 @@
     </div>
 
     <div class="mb-4">
+      <label
+        class="block text-sm font-medium text-gray-700 mb-1"
+        for="min_quantity"
+      >Restock Alert Level</label>
+      <input
+        id="min_quantity"
+        v-model.number="newItem.minQuantity"
+        type="number"
+        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
+        min="0"
+      >
+    </div>
+
+    <div class="mb-4">
       <label class="block text-sm font-medium text-gray-700 mb-1">SKU Codes</label>
       <input
         v-model="skuInput"
@@ -173,6 +187,7 @@ const newItem = ref({
   price: '',
   feePercent: 20,
   quantity: 1,
+  minQuantity: 0,
   skuCodes: [] as string[]
 });
 
@@ -203,7 +218,8 @@ const isFormValid = computed(() => {
     newItem.value.location.trim() &&
     newItem.value.price.trim() &&
     newItem.value.feePercent >= 0 &&
-    newItem.value.quantity > 0
+    newItem.value.quantity > 0 &&
+    newItem.value.minQuantity >= 0
   );
 });
 
@@ -254,6 +270,7 @@ const handleSubmit = async () => {
         name: newItem.value.name,
         details: newItem.value.details,
         quantity: newItem.value.quantity,
+        min_quantity: newItem.value.minQuantity,
         sku_codes: newItem.value.skuCodes,
         status: newItem.value.status,
         location: newItem.value.location,
@@ -280,6 +297,7 @@ const handleSubmit = async () => {
       price: '',
       feePercent: 20,
       quantity: 1,
+      minQuantity: 0,
       skuCodes: []
     };
     selectedFile.value = null;

--- a/src/components/ItemRow.vue
+++ b/src/components/ItemRow.vue
@@ -38,6 +38,11 @@
     </td>
     <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-600">
       {{ item.quantity }}
+      <span
+        v-if="item.quantity < item.minQuantity"
+        class="text-red-600 ml-1"
+        title="Needs restock"
+      >⚠️</span>
     </td>
     <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-600">
       <span v-if="item.skuCodes && item.skuCodes.length">{{ item.skuCodes.join(', ') }}</span>

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -7,6 +7,8 @@ export interface Item {
   details: string;
   /** How many of this item exist */
   quantity: number;
+  /** Quantity threshold to trigger restock alerts */
+  minQuantity: number;
   /** Optional list of SKU codes for individual units */
   skuCodes: string[];
   status: "not_sold" | "sold" | "sold_paid";
@@ -61,13 +63,14 @@ export function mapRecordToItem(record: any): Item {
     imageUrl: record.image_url ?? '',
     details: record.details,
     quantity: typeof record.quantity === 'number' ? record.quantity : 1,
+    minQuantity: typeof record.min_quantity === 'number' ? record.min_quantity : 0,
     skuCodes,
     status: record.status,
     dateAdded: record.date_added,
     location: record.location,
     price: record.price,
     feePercent: typeof record.fee_percent === 'number' ? record.fee_percent : 20,
-    tags
+    tags,
 
   };
 }


### PR DESCRIPTION
## Summary
- add `minQuantity` field to `Item`
- allow setting the restock alert level in add/edit forms
- store `min_quantity` in Supabase
- compute and show low-stock alerts in the app
- document new feature and migration

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d3d6bcf6483209e8eadfd68291181