### PR TITLE
Add user profile page with sign out

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -12,12 +12,12 @@
             Artwork Tracker
           </h1>
         </div>
-        <button
-          class="bg-red-500 text-white font-semibold px-4 py-2 rounded-md hover:bg-red-600 active:scale-95 transition"
-          @click="signOut"
+        <router-link
+          to="/profile"
+          class="bg-blue-500 text-white font-semibold px-4 py-2 rounded-md hover:bg-blue-600 active:scale-95 transition"
         >
-          Sign Out
-        </button>
+          Profile
+        </router-link>
       </div>
 
       <StatsDisplay :stats="currentStats" />
@@ -248,11 +248,6 @@ const currentStats = ref<Stats>({ items: 0, sold: 0, sold_paid: 0, sold_paid_tot
 const searchQuery = ref('');
 const selectedImage = ref<string | null>(null);
 const exporting = ref(false);
-
-async function signOut() {
-  document.cookie = 'introShown=; path=/; max-age=0';
-  await supabase.auth.signOut();
-}
 
 function clearSearch() {
   searchQuery.value = '';

--- a/src/UserProfile.vue
+++ b/src/UserProfile.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="min-h-screen bg-gray-100 text-gray-900 font-sans">
+    <div class="max-w-screen-xl mx-auto p-4 flex flex-col gap-6">
+      <div class="flex items-center justify-between">
+        <router-link
+          to="/"
+          class="text-blue-600 hover:underline"
+        >
+          &larr; Back
+        </router-link>
+        <h1 class="text-2xl font-bold">
+          User Profile
+        </h1>
+        <span />
+      </div>
+
+      <div class="bg-white rounded shadow p-4">
+        <p class="text-gray-600">
+          User information will appear here in the future.
+        </p>
+      </div>
+
+      <div class="mt-auto text-right">
+        <button
+          class="bg-red-500 text-white font-semibold px-4 py-2 rounded-md hover:bg-red-600 active:scale-95 transition"
+          @click="signOut"
+        >
+          Sign Out
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { supabase } from './supabaseClient'
+
+async function signOut() {
+  document.cookie = 'introShown=; path=/; max-age=0'
+  await supabase.auth.signOut()
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,8 +1,10 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import AppPage from './App.vue';
+import UserProfile from './UserProfile.vue';
 
 const routes = [
   { path: '/', name: 'App', component: AppPage },
+  { path: '/profile', name: 'Profile', component: UserProfile },
 ];
 
 const router = createRouter({


### PR DESCRIPTION
## Summary
- add `UserProfile.vue`
- route `/profile` to new page
- replace sign-out button with profile navigation
- move sign-out action to profile page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687facad6e1c8320b1e910a95c0c37f2