### PR TITLE
Separate export format picker

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -132,9 +132,12 @@
             </option>
           </select>
         </template>
+      </div>
+
+      <div class="mb-4 flex flex-col sm:flex-row sm:items-center sm:space-x-4 space-y-2 sm:space-y-0 flex-wrap">
         <label
           for="exportFormat"
-          class="ml-4 mr-2 text-sm text-gray-700"
+          class="mr-2 text-sm text-gray-700"
         >Format:</label>
         <select
           id="exportFormat"


### PR DESCRIPTION
## Summary
- separate the export format dropdown from the view selector

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6880eaecbb888320ac8c041cc257355c