### PR TITLE
Implement login/signup routing

### DIFF
--- a/src/AppRoot.vue
+++ b/src/AppRoot.vue
@@ -1,28 +1,19 @@
 <template>
   <div>
-    <router-view v-if="loggedIn" />
-    <LoginForm v-else />
+    <router-view />
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, watch } from 'vue';
+import { onMounted } from 'vue';
 import { supabase } from './supabaseClient';
-import LoginForm from './components/LoginForm.vue';
-
-const loggedIn = ref(false);
 
 onMounted(async () => {
   const { data } = await supabase.auth.getSession();
-  loggedIn.value = !!data.session;
-  document.body.style.backgroundColor = loggedIn.value ? '#f3f4f6' : 'rgb(22,23,72)';
-});
-
-watch(loggedIn, (isLoggedIn) => {
-  document.body.style.backgroundColor = isLoggedIn ? '#f3f4f6' : 'rgb(22,23,72)';
+  document.body.style.backgroundColor = data.session ? '#f3f4f6' : 'rgb(22,23,72)';
 });
 
 supabase.auth.onAuthStateChange((_event, session) => {
-  loggedIn.value = !!session;
+  document.body.style.backgroundColor = session ? '#f3f4f6' : 'rgb(22,23,72)';
 });
 </script>

--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -106,9 +106,13 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, withDefaults, defineProps } from 'vue';
 import { supabase } from '../supabaseClient';
 import VueHcaptcha from '@hcaptcha/vue3-hcaptcha';
+
+const props = withDefaults(defineProps<{ startSignup?: boolean }>(), {
+  startSignup: undefined,
+});
 
 const email = ref('');
 const password = ref('');
@@ -124,7 +128,8 @@ if (!siteKey) {
 }
 
 onMounted(() => {
-  isSignup.value = !document.cookie.includes('returningUser=true');
+  const cookieDefault = !document.cookie.includes('returningUser=true');
+  isSignup.value = props.startSignup ?? cookieDefault;
   // Initialize Preline plugins like toggle password
   (window as any).HSStaticMethods?.autoInit();
 });

--- a/src/pages/LandingPage.vue
+++ b/src/pages/LandingPage.vue
@@ -5,10 +5,16 @@
         ConsignEasy
       </div>
       <div class="space-x-4">
-        <button class="text-sm font-medium text-gray-600">
+        <button
+          class="text-sm font-medium text-gray-600"
+          @click="goLogin"
+        >
           Login
         </button>
-        <button class="text-sm font-medium border border-purple-500 text-purple-500 px-4 py-1 rounded">
+        <button
+          class="text-sm font-medium border border-purple-500 text-purple-500 px-4 py-1 rounded"
+          @click="goSignup"
+        >
           Sign Up
         </button>
       </div>
@@ -21,7 +27,10 @@
       <p class="text-lg md:text-xl text-gray-600 mb-6">
         Manage your consignment items all in one place.
       </p>
-      <button class="bg-purple-600 hover:bg-purple-700 text-white px-6 py-3 rounded-lg text-lg">
+      <button
+        class="bg-purple-600 hover:bg-purple-700 text-white px-6 py-3 rounded-lg text-lg"
+        @click="handleGetStarted"
+      >
         Get Started
       </button>
       <p class="mt-2 text-sm text-gray-400">
@@ -35,4 +44,23 @@
 
 <script setup>
 import AnimatedBlob from '@/components/AnimatedBlob.vue'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+
+function goLogin() {
+  router.push('/login')
+}
+
+function goSignup() {
+  router.push('/signup')
+}
+
+function handleGetStarted() {
+  if (document.cookie.includes('returningUser=true')) {
+    router.push('/login')
+  } else {
+    router.push('/signup')
+  }
+}
 </script>

--- a/src/pages/LoginPage.vue
+++ b/src/pages/LoginPage.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="min-h-screen flex items-center justify-center bg-gray-50">
+    <LoginForm :start-signup="false" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import LoginForm from '@/components/LoginForm.vue';
+</script>

--- a/src/pages/SignupPage.vue
+++ b/src/pages/SignupPage.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="min-h-screen flex items-center justify-center bg-gray-50">
+    <LoginForm :start-signup="true" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import LoginForm from '@/components/LoginForm.vue';
+</script>

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,12 +1,23 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import AppPage from './App.vue';
 import UserProfile from './UserProfile.vue';
+import { supabase } from './supabaseClient';
 
 const routes = [
   {
     path: '/',
     name: 'Landing',
     component: () => import('@/pages/LandingPage.vue'),
+  },
+  {
+    path: '/login',
+    name: 'Login',
+    component: () => import('@/pages/LoginPage.vue'),
+  },
+  {
+    path: '/signup',
+    name: 'Signup',
+    component: () => import('@/pages/SignupPage.vue'),
   },
   { path: '/app', name: 'App', component: AppPage },
   { path: '/profile', name: 'Profile', component: UserProfile },
@@ -15,6 +26,19 @@ const routes = [
 const router = createRouter({
   history: createWebHistory(),
   routes,
+});
+
+router.beforeEach(async (to, _from, next) => {
+  const { data } = await supabase.auth.getSession();
+  const isAuthenticated = !!data.session;
+
+  if (!isAuthenticated && (to.path === '/app' || to.path === '/profile')) {
+    next('/login');
+  } else if (isAuthenticated && (to.path === '/login' || to.path === '/signup')) {
+    next('/app');
+  } else {
+    next();
+  }
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- route unauthenticated users to login or signup pages
- enable navigation from the landing page
- allow LoginForm to start in signup or login mode
- show router pages directly in `AppRoot`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68825f31971c8320a2a6c1aec5dc129e