### PR TITLE
Fix AnimatedBlob scene hierarchy

### DIFF
--- a/src/components/AnimatedBlob.vue
+++ b/src/components/AnimatedBlob.vue
@@ -2,15 +2,17 @@
   <div class="fixed bottom-0 right-0 w-48 h-48 md:w-72 md:h-72 pointer-events-none z-10">
     <Renderer orbit-ctrl>
       <PerspectiveCamera :position="[0, 0, 5]" />
-      <AmbientLight :intensity="0.8" />
-      <PointLight :position="[10, 10, 10]" />
-      <Sphere :args="[1, 32, 32]">
-        <meshStandardMaterial
-          color="#7C3AED"
-          roughness="0.2"
-          metalness="0.6"
-        />
-      </Sphere>
+      <Scene>
+        <AmbientLight :intensity="0.8" />
+        <PointLight :position="[10, 10, 10]" />
+        <Sphere :args="[1, 32, 32]">
+          <meshStandardMaterial
+            color="#7C3AED"
+            roughness="0.2"
+            metalness="0.6"
+          />
+        </Sphere>
+      </Scene>
     </Renderer>
   </div>
 </template>
@@ -19,6 +21,7 @@
 import {
   Renderer,
   PerspectiveCamera,
+  Scene,
   AmbientLight,
   PointLight,
   Sphere


### PR DESCRIPTION
## Summary
- insert missing `<Scene>` wrapper for 3D objects in `AnimatedBlob.vue`
- import `Scene` from troisjs

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688262bbc3188320a1be4e14132d309b