### PR TITLE
Fix landing page animation visibility

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -702,6 +702,12 @@
   .bg-white {
     background-color: var(--color-white);
   }
+  .bg-white\/70 {
+    background-color: color-mix(in srgb, #fff 70%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-white) 70%, transparent);
+    }
+  }
   .bg-yellow-100 {
     background-color: var(--color-yellow-100);
   }
@@ -724,6 +730,9 @@
   .object-cover {
     -o-object-fit: cover;
        object-fit: cover;
+  }
+  .p-1 {
+    padding: calc(var(--spacing) * 1);
   }
   .p-4 {
     padding: calc(var(--spacing) * 4);

--- a/src/components/AnimatedLogo.vue
+++ b/src/components/AnimatedLogo.vue
@@ -17,10 +17,9 @@
             :key="i"
           >
             <Mesh :position="[(i - 4.5) * 0.7, 0, 0]">
-              <planeGeometry :args="[0.6, 1.2]" />
-              <meshBasicMaterial
+              <PlaneGeometry :args="[0.6, 1.2]" />
+              <BasicMaterial
                 :map="texture"
-
                 transparent
                 :side="2"
               >
@@ -32,12 +31,19 @@
                   name="repeat"
                   :args="[0.125, 1]"
                 />
-              </meshBasicMaterial>
+              </BasicMaterial>
             </Mesh>
           </template>
         </Group>
       </Scene>
     </Renderer>
+    <!-- simple debug indicator -->
+    <div
+      v-if="DEBUG"
+      class="absolute top-0 left-0 text-xs bg-white/70 p-1"
+    >
+      Playing: {{ isPlaying }}
+    </div>
   </div>
 </template>
 
@@ -56,6 +62,9 @@ import { TextureLoader, type Texture } from 'three'
 
 const texture = ref<Texture | null>(null)
 const logoGroup = ref<any>(null)
+const renderer = ref<any>(null)
+const isPlaying = ref(false)
+const DEBUG = true
 
 
 onMounted(() => {
@@ -65,16 +74,16 @@ onMounted(() => {
     (tex) => {
       texture.value = tex
       tex.needsUpdate = true
+      if (DEBUG) console.log('Texture loaded')
     }
   )
 
-  // simple rotation loop to verify the canvas is active
-  const animate = () => {
+  // rotate using renderer's render loop
+  renderer.value?.onBeforeRender(() => {
     if (logoGroup.value) {
       logoGroup.value.rotation.y += 0.01
+      isPlaying.value = true
     }
-    requestAnimationFrame(animate)
-  }
-  animate()
+  })
 })
 </script>


### PR DESCRIPTION
## Summary
- use `<BasicMaterial>` so three.js materials instantiate correctly
- keep debug overlay showing animation play state

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688547631b2c8320a8eaea90564d97eb