### PR TITLE
Fix landing logo loop and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ item-tracker-app/
 ```
 
 ## Landing Page
-When the application loads, an animation briefly appears on top of the main page. After about five seconds the animation disappears, revealing the app at the root path `/` without changing the URL.
+When the application loads, a 3D animated logo plays in the background. The animation keeps running on the landing page until the visitor chooses **Login** or **Sign Up** to move on.
 
 ## Technology Stack
 

--- a/public/main.css
+++ b/public/main.css
@@ -702,6 +702,12 @@
   .bg-white {
     background-color: var(--color-white);
   }
+  .bg-white\/70 {
+    background-color: color-mix(in srgb, #fff 70%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-white) 70%, transparent);
+    }
+  }
   .bg-yellow-100 {
     background-color: var(--color-yellow-100);
   }
@@ -724,6 +730,9 @@
   .object-cover {
     -o-object-fit: cover;
        object-fit: cover;
+  }
+  .p-1 {
+    padding: calc(var(--spacing) * 1);
   }
   .p-4 {
     padding: calc(var(--spacing) * 4);

--- a/src/components/AnimatedLogo.vue
+++ b/src/components/AnimatedLogo.vue
@@ -17,10 +17,9 @@
             :key="i"
           >
             <Mesh :position="[(i - 4.5) * 0.7, 0, 0]">
-              <planeGeometry :args="[0.6, 1.2]" />
-              <meshBasicMaterial
+              <PlaneGeometry :args="[0.6, 1.2]" />
+              <BasicMaterial
                 :map="texture"
-
                 transparent
                 :side="2"
               >
@@ -32,17 +31,24 @@
                   name="repeat"
                   :args="[0.125, 1]"
                 />
-              </meshBasicMaterial>
+              </BasicMaterial>
             </Mesh>
           </template>
         </Group>
       </Scene>
     </Renderer>
+    <!-- simple debug indicator -->
+    <div
+      v-if="DEBUG"
+      class="absolute top-0 left-0 text-xs bg-white/70 p-1"
+    >
+      Playing: {{ isPlaying }} Loaded: {{ textureLoaded }}
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, nextTick } from 'vue'
 import {
   Renderer,
   PerspectiveCamera,
@@ -55,26 +61,34 @@ import {
 import { TextureLoader, type Texture } from 'three'
 
 const texture = ref<Texture | null>(null)
+const textureLoaded = ref(false)
 const logoGroup = ref<any>(null)
+const renderer = ref<any>(null)
+const isPlaying = ref(false)
+const DEBUG = true
 
 
 onMounted(() => {
   const loader = new TextureLoader()
+  loader.setCrossOrigin('anonymous')
   loader.load(
     'https://ielukqallxtceqmobmvp.supabase.co/storage/v1/object/public/images/uglysmall.png',
     (tex) => {
       texture.value = tex
       tex.needsUpdate = true
+      textureLoaded.value = true
+      if (DEBUG) console.log('Texture loaded')
     }
   )
 
-  // simple rotation loop to verify the canvas is active
-  const animate = () => {
-    if (logoGroup.value) {
-      logoGroup.value.rotation.y += 0.01
-    }
-    requestAnimationFrame(animate)
-  }
-  animate()
+  // rotate using renderer's render loop
+  nextTick(() => {
+    renderer.value?.onBeforeRender(() => {
+      if (logoGroup.value) {
+        logoGroup.value.rotation.y += 0.01
+        isPlaying.value = true
+      }
+    })
+  })
 })
 </script>


### PR DESCRIPTION
## Summary
- fix AnimatedLogo rotation hook
- add texture load debugging
- show debug overlay with texture status
- update landing page README description

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688547631b2c8320a8eaea90564d97eb