### PR TITLE
Use animated blob on landing page

### DIFF
--- a/src/components/AnimatedBlob.vue
+++ b/src/components/AnimatedBlob.vue
@@ -1,11 +1,18 @@
 <template>
   <div class="fixed bottom-0 right-0 w-48 h-48 md:w-72 md:h-72 pointer-events-none z-10">
-    <Renderer orbit-ctrl>
+    <Renderer
+      ref="renderer"
+      :orbit-ctrl="{ enableZoom: false, enablePan: false }"
+      class="w-full h-full"
+    >
       <PerspectiveCamera :position="[0, 0, 5]" />
       <Scene>
         <AmbientLight :intensity="0.8" />
         <PointLight :position="[10, 10, 10]" />
-        <Sphere :args="[1, 32, 32]">
+        <Sphere
+          ref="blob"
+          :args="[1, 32, 32]"
+        >
           <meshStandardMaterial
             color="#7C3AED"
             roughness="0.2"
@@ -18,6 +25,7 @@
 </template>
 
 <script setup>
+import { ref, nextTick } from 'vue'
 import {
   Renderer,
   PerspectiveCamera,
@@ -26,4 +34,18 @@ import {
   PointLight,
   Sphere
 } from 'troisjs'
+
+const blob = ref<any>(null)
+const renderer = ref<any>(null)
+
+nextTick(() => {
+  renderer.value?.onMounted(() => {
+    renderer.value?.onBeforeRender(() => {
+      if (blob.value) {
+        blob.value.rotation.x += 0.01
+        blob.value.rotation.y += 0.01
+      }
+    })
+  })
+})
 </script>

--- a/src/components/AnimatedLogo.vue
+++ b/src/components/AnimatedLogo.vue
@@ -38,10 +38,12 @@
       </Scene>
     </Renderer>
 
-    <div v-if="DEBUG" class="absolute top-0 left-0 text-xs bg-white/70 p-1">
+    <div
+      v-if="DEBUG"
+      class="absolute top-0 left-0 text-xs bg-white/70 p-1"
+    >
       Playing: {{ isPlaying }} Loaded: {{ textureLoaded }} Renderer: {{ rendererReady }}
       <span v-if="loadError"> Error: {{ loadError }} </span>
-
     </div>
   </div>
 </template>

--- a/src/pages/LandingPage.vue
+++ b/src/pages/LandingPage.vue
@@ -38,12 +38,12 @@
       </p>
     </main>
 
-    <AnimatedLogo />
+    <AnimatedBlob />
   </div>
 </template>
 
 <script setup>
-import AnimatedLogo from '@/components/AnimatedLogo.vue'
+import AnimatedBlob from '@/components/AnimatedBlob.vue'
 import { useRouter } from 'vue-router'
 
 const router = useRouter()


### PR DESCRIPTION
## Summary
- animate the blob geometry in `AnimatedBlob.vue`
- replace the animated logo with the animated blob on the landing page
- minor lint-driven formatting fix in `AnimatedLogo.vue`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6889029785c483208e0421be97750670