### PR TITLE
Persist item deletions to Supabase

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -587,10 +587,20 @@ const resetItemForNewVersion = async (id: string) => {
 };
 
 // Handle deleting an item
-const deleteItem = (id: string) => {
+const deleteItem = async (id: string) => {
   if (DEBUG) console.log('Deleting item:', id);
-  items.value = items.value.filter(item => item.id !== id);
-  currentStats.value = calculateStats(items.value);
+  try {
+    const { error } = await supabase
+      .from('items')
+      .delete()
+      .eq('id', id);
+    if (error) throw error;
+    items.value = items.value.filter(item => item.id !== id);
+    currentStats.value = calculateStats(items.value);
+  } catch (err: any) {
+    console.error(err);
+    alert('❌ Error deleting item: ' + err.message);
+  }
 };
 
 async function duplicateItem(item: Item) {


### PR DESCRIPTION
## Summary
- ensure items are removed from Supabase when deleted to prevent reappearing on refresh

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892751993f88320a868f6e138b27734