### PR TITLE
feat: add initial loading placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,9 @@
     </style>
   </head>
   <body>
-    <div id="app"></div>
+    <div id="app">
+      <p class="text-center mt-4">Loading...</p>
+    </div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,9 @@ const app = createApp(AppRoot);
 
 app.use(router);
 
-app.mount('#app');
+router.isReady().then(() => {
+  app.mount('#app');
+});
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- render a simple loading message before Vue bootstraps to avoid initial blank screen
- delay Vue mount until router is ready

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893649d522c8320ba3d708ba2cea2a1