### PR TITLE
Rename app to ConsignTracker with UglyStuff.ca branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Item Tracker App
+# ConsignTracker by UglyStuff.ca
 
 A single-page application built with Vue 3 and TypeScript for tracking items with images and sales status.
 
@@ -32,8 +32,8 @@ A single-page application built with Vue 3 and TypeScript for tracking items wit
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/item-tracker-app.git
-cd item-tracker-app
+ git clone https://github.com/yourusername/consigntracker.git
+ cd consigntracker
 
 # Install dependencies
 npm install
@@ -65,7 +65,7 @@ Add your **hCaptcha secret key** in the Supabase Dashboard under **Settings → 
 ## Project Structure
 
 ```
-item-tracker-app/
+consigntracker/
 ├── public/
 │   ├── Uglyico.ico
 │   ├── manifest.webmanifest
@@ -104,7 +104,7 @@ When the application loads, a 3D animated logo plays in the background. The anim
 
 The application now includes basic email/password authentication powered by
 Supabase. On first load, a login form appears after the startup animation. Users
-can sign up or sign in, and the item tracker only loads once a session is
+can sign up or sign in, and ConsignTracker only loads once a session is
 active.
 
 To create an account, enter your email address and a password of your choice in the form and click **Sign Up**. Use the **Login** button if you already have an account.

--- a/docs/SUPABASE_AUTH_SETUP.md
+++ b/docs/SUPABASE_AUTH_SETUP.md
@@ -50,7 +50,7 @@ export async function login(email: string, password: string) {
 }
 ```
 
-Listen for changes with `supabase.auth.onAuthStateChange` and show your item tracker only when a user is logged in.
+Listen for changes with `supabase.auth.onAuthStateChange` and show ConsignTracker only when a user is logged in.
 
 ## 6. Startup screen and main page loading
 
@@ -73,7 +73,7 @@ supabase.auth.onAuthStateChange((_event, session) => {
 });
 ```
 
-When `loggedIn` is `false`, display `<LoginForm />` instead of the item tracker. Once the user logs in, the main page loads normally.
+When `loggedIn` is `false`, display `<LoginForm />` instead of ConsignTracker. Once the user logs in, the main page loads normally.
 
 ## 7. Reverting if something goes wrong
 

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Artwork Tracker</title>
+      <title>ConsignTracker by UglyStuff.ca</title>
     <!-- Load main styles early to prevent flashes -->
     <link rel="stylesheet" href="/main.css" />
     <style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "item-tracker",
+    "name": "consigntracker",
     "version": "0.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "item-tracker",
+            "name": "consigntracker",
             "version": "0.1.0",
             "dependencies": {
                 "@hcaptcha/vue3-hcaptcha": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "item-tracker",
+    "name": "consigntracker",
     "version": "0.1.0",
     "private": true,
     "type": "module",

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/Uglyico.ico" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Item Tracker</title>
+      <title>ConsignTracker by UglyStuff.ca</title>
   </head>
   <body>
     <div id="app"></div>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,6 +1,7 @@
 {
-  "name": "Item Tracker",
-  "short_name": "ItemTracker",
+  "name": "ConsignTracker",
+  "short_name": "ConsignTracker",
+  "description": "ConsignTracker by UglyStuff.ca",
   "start_url": ".",
   "display": "standalone",
   "background_color": "#000000",

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,11 +5,12 @@
         <div class="flex items-center space-x-2 flex-1">
           <img
             src="https://ielukqallxtceqmobmvp.supabase.co/storage/v1/object/public/images//uglysmall.png"
-            alt="Artwork Tracker logo"
+            alt="ConsignTracker logo"
             class="w-8 h-8 object-contain"
           >
-          <h1 class="text-3xl font-bold">
-            Artwork Tracker
+          <h1 class="text-3xl font-bold leading-tight">
+            ConsignTracker
+            <span class="block text-sm font-normal">by UglyStuff.ca</span>
           </h1>
         </div>
         <div

--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -3,11 +3,12 @@
     <div class="flex flex-col items-center mb-4">
       <img
         src="https://ielukqallxtceqmobmvp.supabase.co/storage/v1/object/public/images//1749825362414.png"
-        alt="Artwork Tracker logo"
+        alt="ConsignTracker logo"
         class="w-24 h-24 mb-2"
       >
-      <h2 class="text-2xl font-bold text-center">
-        Artwork Tracker
+      <h2 class="text-2xl font-bold text-center leading-tight">
+        ConsignTracker
+        <span class="block text-sm font-normal">by UglyStuff.ca</span>
       </h2>
     </div>
     <h2 class="text-xl font-semibold mb-4 text-center">
@@ -84,7 +85,7 @@
         >
           <p>
             You can install this web app to run it like a native application.
-            On Chrome, open the browser menu and choose <em>Install Item Tracker</em>.
+            On Chrome, open the browser menu and choose <em>Install ConsignTracker</em>.
             On Safari, tap the share icon and select <em>Add to Home Screen</em>.
           </p>
         </div>

--- a/src/pages/LandingPage.vue
+++ b/src/pages/LandingPage.vue
@@ -1,8 +1,9 @@
 <template>
-  <div class="relative min-h-screen text-center flex flex-col items-center justify-center px-6">
+  <div class="relative min-h-screen flex flex-col items-start justify-center px-6">
     <header class="absolute top-0 left-0 w-full flex justify-between items-center p-4">
-      <div class="text-2xl font-bold">
-        ConsignEasy
+      <div class="text-2xl font-bold leading-tight">
+        ConsignTracker
+        <span class="block text-sm font-normal">by UglyStuff.ca</span>
       </div>
       <div class="space-x-4">
         <button
@@ -20,8 +21,8 @@
       </div>
     </header>
 
-    <main class="z-20 mt-20">
-      <h1 class="text-4xl md:text-6xl font-extrabold mb-4">
+    <main class="z-20 mt-20 text-left">
+      <h1 class="text-[2.475rem] md:text-[4.125rem] font-extrabold mb-4">
         Track, Sell,<br>and Succeed.
       </h1>
       <p class="text-lg md:text-xl text-gray-600 mb-6">
@@ -37,13 +38,10 @@
         Free to try. No credit card required.
       </p>
     </main>
-
-    <AnimatedBlob />
   </div>
 </template>
 
 <script setup>
-import AnimatedBlob from '@/components/AnimatedBlob.vue'
 import { useRouter } from 'vue-router'
 
 const router = useRouter()

--- a/src/utils/exportPdf.ts
+++ b/src/utils/exportPdf.ts
@@ -23,7 +23,7 @@ export async function exportItemsToPdf(items: Item[]): Promise<void> {
   const rowHeight = 40;
 
   doc.setFontSize(18);
-  doc.text('Item Tracker', pageWidth / 2, 15, { align: 'center' });
+  doc.text('ConsignTracker', pageWidth / 2, 15, { align: 'center' });
 
   // Attempt to load and draw the logo
   try {


### PR DESCRIPTION
## Summary
- rebrand site and docs to "ConsignTracker" with "by UglyStuff.ca" tagline
- update manifest, package metadata, and PDF export for new name

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68937d3a13b48320ab7d540e797a9249