### PR TITLE
Improve security and type safety

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -259,8 +259,6 @@ import { calculateStats, saveStats, type Stats } from './utils/stats';
 import { signOut } from './utils/auth';
 import { useRouter } from 'vue-router';
 
-const DEBUG = import.meta.env.VITE_DEBUG === 'true';
-
 
 // Items state
 const router = useRouter();
@@ -307,12 +305,10 @@ function goTo(path: string) {
 }
 
 function reportIssue() {
-  console.log('Report an issue');
   closeMenu();
 }
 
 function requestFeature() {
-  console.log('Request a feature');
   closeMenu();
 }
 
@@ -376,7 +372,7 @@ async function fetchItems() {
     const stats = calculateStats(items.value);
     currentStats.value = stats;
     await saveStats(stats);
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error('Error fetching items:', err);
     serverError.value = 'Error fetching items';
     items.value = [];
@@ -400,7 +396,6 @@ let retryTimeout: number | undefined;
 async function attemptSave() {
   try {
     serverError.value = '';
-    if (DEBUG) console.log('Saving items to server...');
 
     const response = await fetch('/.netlify/functions/saveItems', {
       method: 'POST',
@@ -412,7 +407,6 @@ async function attemptSave() {
       throw new Error(`Server error: ${response.status}`);
     }
 
-    if (DEBUG) console.log('Items saved to server successfully');
 
     const stats = calculateStats(items.value);
     currentStats.value = stats;
@@ -426,7 +420,6 @@ async function attemptSave() {
 
     try {
       localStorage.setItem('itemTrackerItems', JSON.stringify(items.value));
-      if (DEBUG) console.log('Items saved to localStorage as fallback');
       const stats = calculateStats(items.value);
       currentStats.value = stats;
       await saveStats(stats);
@@ -447,7 +440,6 @@ function scheduleRetry() {
   }
   retryTimeout = setTimeout(async () => {
     retryTimeout = undefined;
-    if (DEBUG) console.log('Retrying save to server...');
     const success = await attemptSave();
     if (!success) {
       retryCount++;
@@ -471,7 +463,6 @@ watch(items, () => {
 
 // Handle adding a new item
 const handleItemAdded = (newItem: Item) => {
-  if (DEBUG) console.log('Adding new item:', newItem);
   items.value = [...items.value, newItem]; // Create a new array to ensure reactivity
   currentStats.value = calculateStats(items.value);
   showForm.value = false;
@@ -505,7 +496,6 @@ const updateItemStatus = async (
   id: string,
   status: "not_sold" | "sold" | "sold_paid"
 ) => {
-  if (DEBUG) console.log("Updating item status:", id, status);
 
   try {
     const itemIndex = items.value.findIndex(item => item.id === id);
@@ -542,7 +532,7 @@ const updateItemStatus = async (
       items.value = updatedItems;
       currentStats.value = calculateStats(items.value);
     }
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error(err);
     alert("❌ Error updating status: " + err.message);
   }
@@ -552,7 +542,6 @@ const updateItemStatus = async (
 // This marks the item as available again while preserving its cumulative
 // sold counts so we can track how many versions have moved over time.
 const resetItemForNewVersion = async (id: string) => {
-  if (DEBUG) console.log('Resetting item for new version:', id);
   try {
     const itemIndex = items.value.findIndex(item => item.id === id);
     const existing = items.value[itemIndex];
@@ -576,7 +565,7 @@ const resetItemForNewVersion = async (id: string) => {
       items.value = updatedItems;
       currentStats.value = calculateStats(items.value);
     }
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error(err);
     alert('❌ Error resetting item: ' + err.message);
   }
@@ -584,7 +573,6 @@ const resetItemForNewVersion = async (id: string) => {
 
 // Handle deleting an item
 const deleteItem = async (id: string) => {
-  if (DEBUG) console.log('Deleting item:', id);
   try {
     const { error } = await supabase
       .from('items')
@@ -593,14 +581,13 @@ const deleteItem = async (id: string) => {
     if (error) throw error;
     items.value = items.value.filter(item => item.id !== id);
     currentStats.value = calculateStats(items.value);
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error(err);
     alert('❌ Error deleting item: ' + err.message);
   }
 };
 
 async function duplicateItem(item: Item) {
-  if (DEBUG) console.log('Duplicating item:', item.id);
   try {
     const { data: userData } = await supabase.auth.getUser();
     const user = userData.user;
@@ -630,7 +617,7 @@ async function duplicateItem(item: Item) {
     const newItem: Item = mapRecordToItem(inserted);
     items.value = [newItem, ...items.value];
     currentStats.value = calculateStats(items.value);
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error(err);
     alert('❌ Error duplicating item: ' + err.message);
   }

--- a/src/components/AnimatedLogo.vue
+++ b/src/components/AnimatedLogo.vue
@@ -61,18 +61,24 @@ import {
   PlaneGeometry,
   BasicMaterial
 } from 'troisjs'
-import { TextureLoader, type Texture } from 'three'
+import { TextureLoader, type Texture, type Group as ThreeGroup } from 'three'
 
 const texture = ref<Texture | null>(null)
 const textureLoaded = ref(false)
 
 const loadError = ref('')
-const logoGroup = ref<any>(null)
-const renderer = ref<any>(null)
+const logoGroup = ref<ThreeGroup | null>(null)
+/* eslint-disable no-unused-vars */
+interface TroisRenderer {
+  onMounted(cb: () => void): void
+  onBeforeRender(cb: () => void): void
+}
+/* eslint-enable no-unused-vars */
+const renderer = ref<TroisRenderer | null>(null)
 const rendererReady = ref(false)
 
 const isPlaying = ref(false)
-const DEBUG = true
+const DEBUG = import.meta.env.DEV
 
 
 onMounted(() => {

--- a/src/components/EditItemForm.vue
+++ b/src/components/EditItemForm.vue
@@ -388,7 +388,7 @@ async function handleSubmit() {
     const item: Item = mapRecordToItem(updated);
 
     emit('item-updated', item);
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error(err);
     alert('❌ Error updating item: ' + err.message);
   } finally {

--- a/src/components/ImageCropper.vue
+++ b/src/components/ImageCropper.vue
@@ -41,7 +41,7 @@ import 'cropperjs/dist/cropper.css';
 defineProps<{ src: string; visible: boolean }>();
 const emit = defineEmits<{ cropped: [File]; cancel: [] }>();
 
-const cropper = ref<any>(null);
+const cropper = ref<InstanceType<typeof VueCropper> | null>(null);
 
 function cropImage() {
   const canvas = cropper.value?.getCroppedCanvas();

--- a/src/components/ItemForm.vue
+++ b/src/components/ItemForm.vue
@@ -341,7 +341,7 @@ const handleSubmit = async () => {
     selectedFile.value = null;
     previewUrl.value = '';
     skuInput.value = '';
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error(err);
     alert('❌ Error saving item: ' + err.message);
   } finally {

--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -138,7 +138,8 @@ onMounted(() => {
 });
 
 function setReturningUserCookie() {
-  document.cookie = 'returningUser=true; path=/; max-age=31536000';
+  const secure = location.protocol === 'https:' ? '; Secure' : '';
+  document.cookie = `returningUser=true; path=/; max-age=31536000; SameSite=Strict${secure}`;
 }
 
 function onVerify(token: string) {

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -31,8 +31,26 @@ export const statusOptions = [
   { value: "sold", label: "Sold" },
   { value: "sold_paid", label: "Paid" }
 ] as const;
+export interface ItemRecord {
+  id: string;
+  user_id?: string;
+  name: string;
+  image_url?: string | null;
+  details?: string;
+  quantity?: number | string;
+  min_quantity?: number | string;
+  sku_codes?: string[] | string | null;
+  sold_counts?: Record<string, number> | string | null;
+  past_sales?: number | string;
+  status: "not_sold" | "sold" | "sold_paid";
+  date_added: string;
+  location: string;
+  price: string;
+  fee_percent?: number | string;
+  tags?: string[] | string | null;
+}
 
-export function mapRecordToItem(record: any): Item {
+export function mapRecordToItem(record: ItemRecord): Item {
   let tags: string[] = [];
   if (Array.isArray(record.tags)) {
     tags = record.tags;


### PR DESCRIPTION
## Summary
- remove leftover debug logs from the main app component
- add security attributes when setting the returning-user cookie
- replace several `any` usages with typed interfaces and refs

## Testing
- `npx eslint .`
- `npx vue-tsc --noEmit` (fails: ScriptKind is not defined)
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_68953d80f1808320b432f1bb9d5dd536