### PR TITLE
feat: cache item data for offline use

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Run [docs/MIGRATION_ADD_MIN_QUANTITY.sql](docs/MIGRATION_ADD_MIN_QUANTITY.sql) t
 
 ## Service Worker Caching
 
-Images fetched from Supabase storage are cached using a service worker located at `public/sw.js`. The worker is automatically registered in `src/main.ts` and serves cached images on subsequent visits.
+Images and item data fetched from Supabase are cached using a service worker located at `public/sw.js`. Images use a cache-first strategy, while item API responses use a network-first strategy with a cached fallback. The worker is automatically registered in `src/main.ts`, allowing previously viewed items to remain accessible offline.
 
 ## License
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,25 +1,50 @@
-const CACHE_NAME = 'image-cache-v1';
+const IMAGE_CACHE = 'image-cache-v1';
+const API_CACHE = 'api-cache-v1';
+
+async function cacheFirst(request, cacheName) {
+  const cache = await caches.open(cacheName);
+  const cached = await cache.match(request);
+  if (cached) {
+    return cached;
+  }
+  const response = await fetch(request);
+  if (response.status === 200) {
+    cache.put(request, response.clone());
+  }
+  return response;
+}
+
+async function networkFirst(request, cacheName) {
+  const cache = await caches.open(cacheName);
+  try {
+    const response = await fetch(request);
+    if (response.status === 200) {
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch (err) {
+    const cached = await cache.match(request);
+    if (cached) {
+      return cached;
+    }
+    throw err;
+  }
+}
 
 self.addEventListener('fetch', event => {
   const url = new URL(event.request.url);
+
+  // Cache Supabase storage images using a cache-first strategy
   if (
     url.origin.includes('.supabase.co') &&
     url.pathname.includes('/storage/v1/object/public/images')
   ) {
-    event.respondWith(
-      caches.open(CACHE_NAME).then(cache =>
-        cache.match(event.request).then(cached => {
-          if (cached) {
-            return cached;
-          }
-          return fetch(event.request).then(response => {
-            if (response.status === 200) {
-              cache.put(event.request, response.clone());
-            }
-            return response;
-          });
-        })
-      )
-    );
+    event.respondWith(cacheFirst(event.request, IMAGE_CACHE));
+    return;
+  }
+
+  // Cache Supabase item data using a network-first strategy with fallback
+  if (url.origin.includes('.supabase.co') && url.pathname.startsWith('/rest/v1/items')) {
+    event.respondWith(networkFirst(event.request, API_CACHE));
   }
 });


### PR DESCRIPTION
## Summary
- cache Supabase item API responses in service worker
- document offline caching behavior

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689624f321408320abe9b0cf989c8ca6