### PR TITLE
Fix Sales Chart layout and empty state

### DIFF
--- a/src/components/SoldDetailsModal.vue
+++ b/src/components/SoldDetailsModal.vue
@@ -129,17 +129,19 @@
         <h3 class="mb-2 text-lg font-semibold">
           Sales Chart
         </h3>
-        <canvas
-          v-if="hasChartData"
-          ref="chartCanvas"
-          class="w-full h-64"
-        />
-        <p
-          v-else
-          class="text-center text-gray-500"
-        >
-          No sales data
-        </p>
+        <div class="w-full h-64">
+          <canvas
+            v-if="hasChartData"
+            ref="chartCanvas"
+            class="w-full h-full"
+          />
+          <p
+            v-else
+            class="flex items-center justify-center h-full text-center text-gray-500"
+          >
+            No sales data
+          </p>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- constrain sales chart height to avoid excessive scroll
- show "No sales data" placeholder when chart has no content
- allow Sold stats tile to open Sold Items Details modal

## Testing
- `npm run lint`
- `CI=1 npm run test:unit`
- `CI=1 npm run test:e2e` *(fails: Xvfb not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689e07ef3fdc8320990239b0ed5dae27