### PR TITLE
Fix Sales Chart layout and Sold Details page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -79,16 +79,7 @@
         </div>
       </div>
 
-      <StatsDisplay
-        :stats="currentStats"
-        @show-sold-details="showSoldDetails = true"
-      />
-
-      <SoldDetailsModal
-        v-if="showSoldDetails"
-        :items="items"
-        @close="showSoldDetails = false"
-      />
+      <StatsDisplay :stats="currentStats" />
 
       <div
         v-if="lowStockItems.length"
@@ -251,7 +242,6 @@ import ItemTable from './components/ItemTable.vue';
 import StatsDisplay from './components/StatsDisplay.vue';
 import ImageViewer from './components/ImageViewer.vue';
 import ExportModal from './components/ExportModal.vue';
-import SoldDetailsModal from './components/SoldDetailsModal.vue';
 import type { Item } from './types/item';
 import { mapRecordToItem, availableQuantity, NO_SKU_KEY } from './types/item';
 import { supabase } from './supabaseClient';
@@ -275,7 +265,6 @@ const searchQuery = ref('');
 const selectedImage = ref<string | null>(null);
 const showMenu = ref(false);
 const showExportModal = ref(false);
-const showSoldDetails = ref(false);
 const menuRef = ref<HTMLElement | null>(null);
 
 function clearSearch() {

--- a/src/components/StatsDisplay.vue
+++ b/src/components/StatsDisplay.vue
@@ -8,9 +8,9 @@
         {{ props.stats.items }}
       </p>
     </div>
-    <div
-      class="bg-white rounded-xl shadow-md p-4 text-center cursor-pointer"
-      @click="emit('show-sold-details')"
+    <router-link
+      to="/sold-details"
+      class="block bg-white rounded-xl shadow-md p-4 text-center cursor-pointer"
     >
       <h2 class="text-sm text-gray-500 uppercase">
         Sold
@@ -24,7 +24,7 @@
           :style="{ width: soldPercent + '%' }"
         />
       </div>
-    </div>
+    </router-link>
     <div class="bg-white rounded-xl shadow-md p-4 text-center">
       <h2 class="text-sm text-gray-500 uppercase">
         Paid
@@ -72,8 +72,6 @@ import type { Stats } from '../utils/stats';
 const props = defineProps<{
   stats: Stats;
 }>();
-
-const emit = defineEmits(['show-sold-details']);
 
 const showOutstanding = ref(false);
 const toggleOutstanding = () => {

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import AppPage from './App.vue';
 import UserProfile from './UserProfile.vue';
+import SoldDetails from './SoldDetails.vue';
 import { supabase } from './supabaseClient';
 
 const routes = [
@@ -21,6 +22,7 @@ const routes = [
   },
   { path: '/app', name: 'App', component: AppPage },
   { path: '/profile', name: 'Profile', component: UserProfile },
+  { path: '/sold-details', name: 'SoldDetails', component: SoldDetails },
 ];
 
 const router = createRouter({
@@ -32,7 +34,10 @@ router.beforeEach(async (to, _from, next) => {
   const { data } = await supabase.auth.getSession();
   const isAuthenticated = !!data.session;
 
-  if (!isAuthenticated && (to.path === '/app' || to.path === '/profile')) {
+  if (
+    !isAuthenticated &&
+    (to.path === '/app' || to.path === '/profile' || to.path === '/sold-details')
+  ) {
     next('/login');
   } else if (isAuthenticated && (to.path === '/login' || to.path === '/signup')) {
     next('/app');


### PR DESCRIPTION
## Summary
- constrain sales chart height to avoid excessive scroll
- show "No sales data" placeholder when chart has no content
- allow Sold stats tile to open Sold Items Details page
- present Sold Items Details as dedicated page with back button

## Testing
- `npm run lint`
- `CI=1 npm run test:unit`
- `CI=1 npm run test:e2e` *(fails: Xvfb not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689e07ef3fdc8320990239b0ed5dae27