### PR TITLE
feat: persist notes to database

### DIFF
--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -10,3 +10,30 @@ export interface Note {
   date?: string;
   createdAt: string;
 }
+
+export interface NoteRecord {
+  id: string;
+  user_id?: string;
+  title: string;
+  item_type?: string | null;
+  sku?: string | null;
+  store?: string | null;
+  text: string;
+  image_url?: string | null;
+  date?: string | null;
+  created_at: string;
+}
+
+export function mapRecordToNote(record: NoteRecord): Note {
+  return {
+    id: record.id,
+    title: record.title,
+    itemType: record.item_type || '',
+    sku: record.sku || '',
+    store: record.store || '',
+    text: record.text,
+    imageUrl: record.image_url || undefined,
+    date: record.date || undefined,
+    createdAt: record.created_at,
+  };
+}


### PR DESCRIPTION
## Summary
- persist note data to Supabase
- convert database rows into note objects

## Testing
- `CI=1 npx vitest run`
- `npx cypress run` *(fails: your system is missing the dependency: Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68b368b908208320be979f4bcf43929d