### PR TITLE
feat: persist notes to database

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ the auth integration works, how to restrict data per user, and how to update an
 existing Supabase project for per-user items. A ready-to-run SQL script is
 available at [docs/SUPABASE_SETUP.sql](docs/SUPABASE_SETUP.sql) to create the
 required table, policies, and storage buckets.
+Run [docs/SUPABASE_NOTES_SETUP.sql](docs/SUPABASE_NOTES_SETUP.sql) to create
+the `notes` table and policies so each user can manage only their own notes.
 If you've already created the `items` table, run
 [docs/MIGRATION_ADD_QUANTITY_AND_SKU.sql](docs/MIGRATION_ADD_QUANTITY_AND_SKU.sql)
 to add the `quantity` and `sku_codes` columns.

--- a/docs/SUPABASE_NOTES_SETUP.sql
+++ b/docs/SUPABASE_NOTES_SETUP.sql
@@ -1,0 +1,31 @@
+-- Setup script for per-user notes
+create table if not exists public.notes (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id) on delete cascade,
+  title text not null,
+  item_type text,
+  sku text,
+  store text,
+  text text not null,
+  image_url text,
+  date date,
+  created_at timestamptz default now()
+);
+
+alter table public.notes enable row level security;
+
+drop policy if exists "Individuals can delete their own notes" on public.notes;
+create policy "Individuals can delete their own notes" on public.notes
+  for delete using ((select auth.uid()) = user_id);
+
+drop policy if exists "Individuals can insert their own notes" on public.notes;
+create policy "Individuals can insert their own notes" on public.notes
+  for insert with check ((select auth.uid()) = user_id);
+
+drop policy if exists "Individuals can update their own notes" on public.notes;
+create policy "Individuals can update their own notes" on public.notes
+  for update using ((select auth.uid()) = user_id);
+
+drop policy if exists "Individuals can view their own notes" on public.notes;
+create policy "Individuals can view their own notes" on public.notes
+  for select using ((select auth.uid()) = user_id);

--- a/src/NotesPage.vue
+++ b/src/NotesPage.vue
@@ -224,7 +224,7 @@
 import { onMounted, ref, computed } from 'vue'
 import { supabase } from './supabaseClient'
 import type { Item } from './types/item'
-import type { Note } from './types/note'
+import { mapRecordToNote, type Note, type NoteRecord } from './types/note'
 
 const form = ref({
   title: '',
@@ -245,14 +245,34 @@ const showForm = ref(false)
 const editingNoteId = ref<string | null>(null)
 
 onMounted(async () => {
-  loadNotes()
+  await loadNotes()
   await fetchOptions()
   checkReminders()
 })
 
-function loadNotes() {
-  const raw = localStorage.getItem('notes')
-  notes.value = raw ? JSON.parse(raw) : []
+async function loadNotes() {
+  const { data: sessionData } = await supabase.auth.getSession()
+  const user = sessionData.session?.user
+  if (!user) {
+    const raw = localStorage.getItem('notes')
+    notes.value = raw ? JSON.parse(raw) : []
+    return
+  }
+
+  const { data, error } = await supabase
+    .from<NoteRecord>('notes')
+    .select('*')
+    .eq('user_id', user.id)
+
+  if (error) {
+    console.error(error)
+    const raw = localStorage.getItem('notes')
+    notes.value = raw ? JSON.parse(raw) : []
+    return
+  }
+
+  notes.value = data ? data.map(mapRecordToNote) : []
+  saveNotes()
 }
 
 function saveNotes() {
@@ -260,8 +280,8 @@ function saveNotes() {
 }
 
 async function fetchOptions() {
-  const { data: userData } = await supabase.auth.getUser()
-  const user = userData.user
+  const { data: sessionData } = await supabase.auth.getSession()
+  const user = sessionData.session?.user
   if (!user) return
 
   const { data: items } = await supabase
@@ -322,17 +342,28 @@ function cancelForm() {
   showForm.value = false
 }
 
-function deleteNote(id: string) {
+async function deleteNote(id: string) {
   notes.value = notes.value.filter(n => n.id !== id)
   saveNotes()
+
+  const { data: sessionData } = await supabase.auth.getSession()
+  const user = sessionData.session?.user
+  if (user) {
+    const { error } = await supabase
+      .from('notes')
+      .delete()
+      .eq('id', id)
+      .eq('user_id', user.id)
+    if (error) console.error(error)
+  }
 }
 
-function saveNote() {
+async function saveNote() {
   if (editingNoteId.value) {
     const index = notes.value.findIndex(n => n.id === editingNoteId.value)
     if (index === -1) return
     const existing = notes.value[index]
-    const finalize = (imageUrl?: string) => {
+    const finalize = async (imageUrl?: string) => {
       existing.title = form.value.title
       existing.itemType = form.value.itemType
       existing.sku = form.value.sku
@@ -344,19 +375,40 @@ function saveNote() {
       }
       saveNotes()
       cancelForm()
+
+      const { data: sessionData } = await supabase.auth.getSession()
+      const user = sessionData.session?.user
+      if (user) {
+        const { error } = await supabase
+          .from('notes')
+          .update({
+            title: existing.title,
+            item_type: existing.itemType || null,
+            sku: existing.sku || null,
+            store: existing.store || null,
+            text: existing.text,
+            image_url: existing.imageUrl,
+            date: existing.date,
+          })
+          .eq('id', existing.id)
+          .eq('user_id', user.id)
+        if (error) console.error(error)
+      }
     }
     if (form.value.image) {
       const reader = new FileReader()
-      reader.onload = () => finalize(reader.result as string)
+      reader.onload = async () => {
+        await finalize(reader.result as string)
+      }
       reader.readAsDataURL(form.value.image)
     } else {
-      finalize()
+      await finalize()
     }
   } else {
     const id = crypto.randomUUID()
     const createdAt = new Date().toISOString()
 
-    const finalize = (imageUrl?: string) => {
+    const finalize = async (imageUrl?: string) => {
       const note: Note = {
         id,
         title: form.value.title,
@@ -371,14 +423,38 @@ function saveNote() {
       notes.value.push(note)
       saveNotes()
       cancelForm()
+
+      const { data: sessionData } = await supabase.auth.getSession()
+      const user = sessionData.session?.user
+      if (user) {
+        const { error } = await supabase
+          .from('notes')
+          .insert([
+            {
+              id,
+              user_id: user.id,
+              title: note.title,
+              item_type: note.itemType || null,
+              sku: note.sku || null,
+              store: note.store || null,
+              text: note.text,
+              image_url: imageUrl,
+              date: note.date,
+              created_at: createdAt,
+            },
+          ])
+        if (error) console.error(error)
+      }
     }
 
     if (form.value.image) {
       const reader = new FileReader()
-      reader.onload = () => finalize(reader.result as string)
+      reader.onload = async () => {
+        await finalize(reader.result as string)
+      }
       reader.readAsDataURL(form.value.image)
     } else {
-      finalize()
+      await finalize()
     }
 
   }

--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -10,3 +10,30 @@ export interface Note {
   date?: string;
   createdAt: string;
 }
+
+export interface NoteRecord {
+  id: string;
+  user_id?: string;
+  title: string;
+  item_type?: string | null;
+  sku?: string | null;
+  store?: string | null;
+  text: string;
+  image_url?: string | null;
+  date?: string | null;
+  created_at: string;
+}
+
+export function mapRecordToNote(record: NoteRecord): Note {
+  return {
+    id: record.id,
+    title: record.title,
+    itemType: record.item_type || '',
+    sku: record.sku || '',
+    store: record.store || '',
+    text: record.text,
+    imageUrl: record.image_url || undefined,
+    date: record.date || undefined,
+    createdAt: record.created_at,
+  };
+}


### PR DESCRIPTION
## Summary
- persist note data to Supabase
- convert database rows into note objects
- fetch user session when syncing notes
- document Supabase `notes` table policies for per-user access

## Testing
- `CI=1 npx vitest run`
- `npx cypress run` *(fails: your system is missing the dependency: Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68b368b908208320be979f4bcf43929d