### PR TITLE
Add store login page using shared login form

### DIFF
--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -60,6 +60,7 @@
           {{ isSignup ? 'Sign Up' : 'Login' }}
         </button>
         <button
+          v-if="props.allowSignup"
           type="button"
           class="text-blue-500"
           @click="toggleMode"
@@ -68,7 +69,7 @@
         </button>
       </div>
       <p class="text-center text-sm text-gray-600">
-        <span v-if="isSignup">Enter your email and a desired password, then click <strong>Sign Up</strong> to create an account.</span>
+        <span v-if="props.allowSignup && isSignup">Enter your email and a desired password, then click <strong>Sign Up</strong> to create an account.</span>
         <span v-else>Enter your email and password to log in.</span>
       </p>
       <div class="text-center">
@@ -112,9 +113,13 @@ import { useRouter } from 'vue-router';
 import { supabase } from '../supabaseClient';
 import VueHcaptcha from '@hcaptcha/vue3-hcaptcha';
 
-const props = withDefaults(defineProps<{ startSignup?: boolean }>(), {
-  startSignup: undefined,
-});
+const props = withDefaults(
+  defineProps<{ startSignup?: boolean; allowSignup?: boolean }>(),
+  {
+    startSignup: undefined,
+    allowSignup: true,
+  },
+);
 
 const email = ref('');
 const password = ref('');
@@ -131,8 +136,12 @@ if (!siteKey) {
 }
 
 onMounted(() => {
-  const cookieDefault = !document.cookie.includes('returningUser=true');
-  isSignup.value = props.startSignup ?? cookieDefault;
+  if (props.allowSignup) {
+    const cookieDefault = !document.cookie.includes('returningUser=true');
+    isSignup.value = props.startSignup ?? cookieDefault;
+  } else {
+    isSignup.value = false;
+  }
   // Initialize Preline plugins like toggle password
   (window as any).HSStaticMethods?.autoInit();
 });
@@ -187,6 +196,7 @@ async function handleSignup() {
 }
 
 function toggleMode() {
+  if (!props.allowSignup) return;
   isSignup.value = !isSignup.value;
   setReturningUserCookie();
 }

--- a/src/pages/StoreLoginPage.vue
+++ b/src/pages/StoreLoginPage.vue
@@ -1,0 +1,10 @@
+<template>
+  <LoginForm
+    :start-signup="false"
+    :allow-signup="false"
+  />
+</template>
+
+<script setup lang="ts">
+import LoginForm from '@/components/LoginForm.vue';
+</script>

--- a/src/router.ts
+++ b/src/router.ts
@@ -20,6 +20,11 @@ const routes = [
     name: 'Signup',
     component: () => import('@/pages/SignupPage.vue'),
   },
+  {
+    path: '/store/login',
+    name: 'StoreLogin',
+    component: () => import('@/pages/StoreLoginPage.vue'),
+  },
   { path: '/app', name: 'App', component: AppPage },
   { path: '/settings', name: 'Settings', component: SettingsPage },
   { path: '/notes', name: 'Notes', component: NotesPage },


### PR DESCRIPTION
## Summary
- allow login form to operate without signup option
- add store-only login page reusing existing UI
- register `/store/login` route

## Testing
- `npm run test:unit -- --run`
- `npm run test:e2e` *(fails: Your system is missing the dependency: Xvfb)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b45ae3099083209761b7b211aeef39