### PR TITLE
Add store login page using shared login form

### DIFF
--- a/netlify/functions/inviteStore.cjs
+++ b/netlify/functions/inviteStore.cjs
@@ -1,0 +1,111 @@
+const nodemailer = require('nodemailer');
+const { createClient } = require('@supabase/supabase-js');
+
+const baseHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, X-Mail-Token',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Content-Type': 'application/json',
+};
+
+exports.handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 200, headers: baseHeaders, body: '' };
+  }
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, headers: baseHeaders, body: JSON.stringify({ error: 'Method not allowed' }) };
+  }
+
+  try {
+    const { email, name, password, loginUrl } = JSON.parse(event.body || '{}');
+
+    if (!email || !password || !loginUrl) {
+      return {
+        statusCode: 400,
+        headers: baseHeaders,
+        body: JSON.stringify({ error: 'Missing required fields' }),
+      };
+    }
+
+    if (process.env.MAIL_TOKEN) {
+      const incoming = event.headers['x-mail-token'] || event.headers['X-Mail-Token'];
+      if (incoming !== process.env.MAIL_TOKEN) {
+        return { statusCode: 401, headers: baseHeaders, body: JSON.stringify({ error: 'Unauthorized' }) };
+      }
+    }
+
+    // Create store user in Supabase
+    const supabaseUrl = process.env.SUPABASE_URL;
+    const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!supabaseUrl || !serviceKey) {
+      return {
+        statusCode: 500,
+        headers: baseHeaders,
+        body: JSON.stringify({ error: 'Missing Supabase configuration' }),
+      };
+    }
+
+    const supabase = createClient(supabaseUrl, serviceKey);
+    const { error: createError } = await supabase.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+      user_metadata: { name, role: 'store' },
+    });
+    if (createError) {
+      console.error('Error creating user:', createError);
+      return {
+        statusCode: 500,
+        headers: baseHeaders,
+        body: JSON.stringify({ error: 'User creation failed', detail: createError.message }),
+      };
+    }
+
+    // Send invite email
+    const host = process.env.SES_HOST;
+    const port = Number(process.env.SES_PORT) || 465;
+    const user = process.env.SES_USER;
+    const pass = process.env.SES_PASS;
+    const from = process.env.MAIL_FROM;
+
+    if (!host || !user || !pass || !from) {
+      return {
+        statusCode: 500,
+        headers: baseHeaders,
+        body: JSON.stringify({ error: 'Missing mail server configuration' }),
+      };
+    }
+
+    const transporter = nodemailer.createTransport({
+      host,
+      port,
+      secure: port === 465,
+      auth: { user, pass },
+    });
+
+    const subject = `Your store login for ${name || email}`;
+    const html = `<p>Hello ${name || ''},</p><p>Your store account has been created.</p><p><strong>Email:</strong> ${email}<br><strong>Password:</strong> ${password}</p><p><a href="${loginUrl}">Log in here</a></p>`;
+
+    const info = await transporter.sendMail({
+      from,
+      to: email,
+      subject,
+      html,
+      text: html.replace(/<[^>]+>/g, ' '),
+    });
+
+    return {
+      statusCode: 200,
+      headers: baseHeaders,
+      body: JSON.stringify({ ok: true, messageId: info.messageId }),
+    };
+  } catch (err) {
+    console.error('Error inviting store:', err);
+    return {
+      statusCode: 500,
+      headers: baseHeaders,
+      body: JSON.stringify({ ok: false, error: err.name || 'INVITE_FAILED', detail: err.message }),
+    };
+  }
+};
+

--- a/src/SettingsPage.vue
+++ b/src/SettingsPage.vue
@@ -150,6 +150,58 @@
           </div>
         </template>
       </div>
+      <div class="bg-white rounded shadow p-4">
+        <h2 class="text-xl font-semibold mb-2">
+          Invite Store Owner
+        </h2>
+        <div class="mb-2">
+          <label class="block text-sm mb-1">Store Name</label>
+          <input
+            v-model="invite.name"
+            type="text"
+            class="w-full px-3 py-2 border rounded"
+          >
+        </div>
+        <div class="mb-2">
+          <label class="block text-sm mb-1">Email</label>
+          <input
+            v-model="invite.email"
+            type="email"
+            class="w-full px-3 py-2 border rounded"
+          >
+        </div>
+        <div class="mb-2">
+          <label class="block text-sm mb-1">Temp Password</label>
+          <div class="flex">
+            <input
+              v-model="invite.password"
+              type="text"
+              class="flex-1 px-3 py-2 border rounded-l"
+            >
+            <button
+              type="button"
+              class="bg-gray-200 px-3 rounded-r hover:bg-gray-300"
+              @click="generatePassword"
+            >
+              Generate
+            </button>
+          </div>
+        </div>
+        <button
+          class="mt-2 bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+          :disabled="inviting"
+          @click="sendInvite"
+        >
+          {{ inviting ? 'Sending...' : 'Send Invite' }}
+        </button>
+        <p
+          v-if="inviteResult"
+          class="mt-2 text-sm"
+          :class="inviteResult.ok ? 'text-green-600' : 'text-red-600'"
+        >
+          {{ inviteResult.message }}
+        </p>
+      </div>
     </div>
   </div>
 </template>
@@ -183,6 +235,9 @@ const tempStores = ref<string[]>([])
 const tempSkus = ref<string[]>([])
 const newStore = ref('')
 const newSku = ref('')
+const invite = ref({ name: '', email: '', password: '' })
+const inviting = ref(false)
+const inviteResult = ref<{ ok: boolean; message: string } | null>(null)
 
 async function fetchProfile() {
   const { data: userData } = await supabase.auth.getUser()
@@ -293,6 +348,37 @@ async function saveCatalog() {
     console.error('Error saving catalog:', err)
   } finally {
     saving.value = false
+  }
+}
+
+function generatePassword() {
+  invite.value.password = Math.random().toString(36).slice(-8)
+}
+
+async function sendInvite() {
+  inviting.value = true
+  inviteResult.value = null
+  try {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+    const token = import.meta.env.VITE_MAIL_TOKEN
+    if (token) headers['X-Mail-Token'] = token
+    const res = await fetch('/.netlify/functions/inviteStore', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ ...invite.value, loginUrl: window.location.origin + '/store/login' })
+    })
+    const data = await res.json()
+    if (res.ok && data.ok) {
+      inviteResult.value = { ok: true, message: 'Invite sent' }
+      invite.value = { name: '', email: '', password: '' }
+    } else {
+      inviteResult.value = { ok: false, message: data.error || 'Failed to send invite' }
+    }
+  } catch (err) {
+    console.error('Error sending invite:', err)
+    inviteResult.value = { ok: false, message: 'Failed to send invite' }
+  } finally {
+    inviting.value = false
   }
 }
 </script>

--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -60,6 +60,7 @@
           {{ isSignup ? 'Sign Up' : 'Login' }}
         </button>
         <button
+          v-if="props.allowSignup"
           type="button"
           class="text-blue-500"
           @click="toggleMode"
@@ -68,7 +69,7 @@
         </button>
       </div>
       <p class="text-center text-sm text-gray-600">
-        <span v-if="isSignup">Enter your email and a desired password, then click <strong>Sign Up</strong> to create an account.</span>
+        <span v-if="props.allowSignup && isSignup">Enter your email and a desired password, then click <strong>Sign Up</strong> to create an account.</span>
         <span v-else>Enter your email and password to log in.</span>
       </p>
       <div class="text-center">
@@ -112,9 +113,13 @@ import { useRouter } from 'vue-router';
 import { supabase } from '../supabaseClient';
 import VueHcaptcha from '@hcaptcha/vue3-hcaptcha';
 
-const props = withDefaults(defineProps<{ startSignup?: boolean }>(), {
-  startSignup: undefined,
-});
+const props = withDefaults(
+  defineProps<{ startSignup?: boolean; allowSignup?: boolean }>(),
+  {
+    startSignup: undefined,
+    allowSignup: true,
+  },
+);
 
 const email = ref('');
 const password = ref('');
@@ -131,8 +136,12 @@ if (!siteKey) {
 }
 
 onMounted(() => {
-  const cookieDefault = !document.cookie.includes('returningUser=true');
-  isSignup.value = props.startSignup ?? cookieDefault;
+  if (props.allowSignup) {
+    const cookieDefault = !document.cookie.includes('returningUser=true');
+    isSignup.value = props.startSignup ?? cookieDefault;
+  } else {
+    isSignup.value = false;
+  }
   // Initialize Preline plugins like toggle password
   (window as any).HSStaticMethods?.autoInit();
 });
@@ -187,6 +196,7 @@ async function handleSignup() {
 }
 
 function toggleMode() {
+  if (!props.allowSignup) return;
   isSignup.value = !isSignup.value;
   setReturningUserCookie();
 }

--- a/src/pages/StoreLoginPage.vue
+++ b/src/pages/StoreLoginPage.vue
@@ -1,0 +1,10 @@
+<template>
+  <LoginForm
+    :start-signup="false"
+    :allow-signup="false"
+  />
+</template>
+
+<script setup lang="ts">
+import LoginForm from '@/components/LoginForm.vue';
+</script>

--- a/src/router.ts
+++ b/src/router.ts
@@ -20,6 +20,11 @@ const routes = [
     name: 'Signup',
     component: () => import('@/pages/SignupPage.vue'),
   },
+  {
+    path: '/store/login',
+    name: 'StoreLogin',
+    component: () => import('@/pages/StoreLoginPage.vue'),
+  },
   { path: '/app', name: 'App', component: AppPage },
   { path: '/settings', name: 'Settings', component: SettingsPage },
   { path: '/notes', name: 'Notes', component: NotesPage },


### PR DESCRIPTION
## Summary
- allow login form to operate without signup option
- add store-only login page reusing existing UI
- register `/store/login` route
- enable inviting store owners from settings and email credentials via Netlify function

## Testing
- `npm run test:unit -- --run`
- `npm run test:e2e` *(fails: Your system is missing the dependency: Xvfb)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b45ae3099083209761b7b211aeef39