### PR TITLE
fix: handle image load error on landing page

### DIFF
--- a/src/pages/LandingPage.vue
+++ b/src/pages/LandingPage.vue
@@ -6,7 +6,7 @@
           src="https://ielukqallxtceqmobmvp.supabase.co/storage/v1/object/public/images//uglysmall.png"
           alt="logo"
           class="h-[3.5rem] w-auto object-contain"
-          @error="(e) => (e.target as HTMLImageElement).src = '/ugly_192px.png'"
+          @error="handleLogoError"
         >
         <div>
           ConsignTracker
@@ -62,7 +62,7 @@
   </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { useRouter } from 'vue-router'
 
 const router = useRouter()
@@ -81,5 +81,9 @@ function handleGetStarted() {
   } else {
     router.push('/signup')
   }
+}
+
+function handleLogoError(e: Event) {
+  (e.target as HTMLImageElement).src = '/ugly_192px.png'
 }
 </script>


### PR DESCRIPTION
## Summary
- move inline logo error handler into typed function to avoid build syntax errors

## Testing
- `npm run lint`
- `npm run test:unit -- --run`
- `npm run test:e2e` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68b626f3aa2c8320b1cba0cdb0997b80