### PR TITLE
Handle AccessDenied in inviteStore function

### DIFF
--- a/netlify/functions/inviteStore.cjs
+++ b/netlify/functions/inviteStore.cjs
@@ -34,11 +34,13 @@ exports.handler = async (event) => {
     const template = process.env.SES_TEMPLATE_INVITE || 'store-invite';
 
     if (!region || !from) {
-
       return {
         statusCode: 500,
         headers: baseHeaders,
-        body: JSON.stringify({ error: 'User invite failed', detail: inviteError.message }),
+        body: JSON.stringify({
+          error: 'User invite failed',
+          detail: 'Missing AWS configuration',
+        }),
       };
     }
 
@@ -64,10 +66,15 @@ exports.handler = async (event) => {
     };
   } catch (err) {
     console.error('Error sending invite:', err);
+    const status = err.name === 'AccessDeniedException' ? 403 : 500;
     return {
-      statusCode: 500,
+      statusCode: status,
       headers: baseHeaders,
-      body: JSON.stringify({ ok: false, error: err.name || 'INVITE_FAILED', detail: err.message }),
+      body: JSON.stringify({
+        ok: false,
+        error: err.name || 'INVITE_FAILED',
+        detail: err.message,
+      }),
     };
   }
 };


### PR DESCRIPTION
## Summary
- fix inviteStore missing AWS configuration error and undefined variable
- return 403 for AWS AccessDenied errors when inviting store owners

## Testing
- `npm run test:unit -- --run`
- `npm run test:e2e` *(fails: missing dependency: Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68b8770903648320a1a338102cc34324