### PR TITLE
refactor: use Supabase for store invites

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,12 +9,7 @@ VITE_HCAPTCHA_SITEKEY=
 SUPABASE_URL=
 SUPABASE_SERVICE_ROLE_KEY=
 
-# Mail server (SES) configuration
-
-SES_HOST=
-SES_PORT=465
-SES_USER=
-SES_PASS=
+# Mail server configuration
 MAIL_FROM=
 MAIL_TO=
 

--- a/netlify/functions/inviteStore.cjs
+++ b/netlify/functions/inviteStore.cjs
@@ -1,5 +1,5 @@
 
-const { SESv2Client, SendEmailCommand } = require('@aws-sdk/client-sesv2');
+const { createClient } = require('@supabase/supabase-js');
 
 const baseHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -17,10 +17,8 @@ exports.handler = async (event) => {
   }
 
   try {
-    const { email, name, signupUrl } = JSON.parse(event.body || '{}');
-
+    const { email, signupUrl } = JSON.parse(event.body || '{}');
     if (!email || !signupUrl) {
-
       return {
         statusCode: 400,
         headers: baseHeaders,
@@ -28,47 +26,47 @@ exports.handler = async (event) => {
       };
     }
 
+    const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+    const serviceKey =
+      process.env.SUPABASE_SERVICE_ROLE_KEY ||
+      process.env.VITE_SUPABASE_SERVICE_ROLE_KEY ||
+      process.env.VITE_SUPABASE_KEY;
 
-    const region = process.env.AWS_REGION || process.env.SES_REGION;
-    const from = process.env.MAIL_FROM;
-    const template = process.env.SES_TEMPLATE_INVITE || 'store-invite';
-
-    if (!region || !from) {
+    if (!supabaseUrl || !serviceKey) {
       return {
         statusCode: 500,
         headers: baseHeaders,
+        body: JSON.stringify({ error: 'Missing Supabase configuration' }),
+      };
+    }
+
+    const supabase = createClient(supabaseUrl, serviceKey);
+    const { data, error } = await supabase.auth.admin.inviteUserByEmail(email, {
+      redirectTo: signupUrl,
+      data: { role: 'store', roles: ['store'] },
+    });
+
+    if (error) {
+      return {
+        statusCode: error.status || 500,
+        headers: baseHeaders,
         body: JSON.stringify({
-          error: 'User invite failed',
-          detail: 'Missing AWS configuration',
+          ok: false,
+          error: error.name || 'INVITE_FAILED',
+          detail: error.message,
         }),
       };
     }
 
-    const ses = new SESv2Client({ region });
-
-    const command = new SendEmailCommand({
-      FromEmailAddress: from,
-      Destination: { ToAddresses: [email] },
-      Content: {
-        Template: {
-          TemplateName: template,
-          TemplateData: JSON.stringify({ name: name || '', signupUrl }),
-        },
-      },
-    });
-
-    await ses.send(command);
-    
     return {
       statusCode: 200,
       headers: baseHeaders,
-      body: JSON.stringify({ ok: true }),
+      body: JSON.stringify({ ok: true, user: data?.user }),
     };
   } catch (err) {
     console.error('Error sending invite:', err);
-    const status = err.name === 'AccessDeniedException' ? 403 : 500;
     return {
-      statusCode: status,
+      statusCode: 500,
       headers: baseHeaders,
       body: JSON.stringify({
         ok: false,


### PR DESCRIPTION
## Summary
- replace AWS SES logic with Supabase admin invite API for store onboarding
- drop unused SES environment variables from example env file

## Testing
- `npm test` *(fails: missing dependency Xvfb for Cypress)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9d7cacba0832099926d35415e199c