### PR TITLE
Add sales details modal with store and month filters

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -82,6 +82,13 @@
 
       <StatsDisplay
         :stats="currentStats"
+        @show-sold-details="showSoldDetails = true"
+      />
+
+      <SoldDetailsModal
+        v-if="showSoldDetails"
+        :items="items"
+        @close="showSoldDetails = false"
       />
 
       <div
@@ -248,6 +255,7 @@ import EditItemForm from './components/EditItemForm.vue';
 import ItemGrid from './components/ItemGrid.vue';
 import ItemTable from './components/ItemTable.vue';
 import StatsDisplay from './components/StatsDisplay.vue';
+import SoldDetailsModal from './components/SoldDetailsModal.vue';
 import ImageViewer from './components/ImageViewer.vue';
 import ExportModal from './components/ExportModal.vue';
 import ContactModal from './components/ContactModal.vue';
@@ -277,6 +285,7 @@ const showExportModal = ref(false);
 const showContact = ref(false);
 const contactSubject = ref('');
 const menuRef = ref<HTMLElement | null>(null);
+const showSoldDetails = ref(false);
 
 function clearSearch() {
   searchQuery.value = '';

--- a/src/components/SoldDetailsModal.vue
+++ b/src/components/SoldDetailsModal.vue
@@ -109,6 +109,24 @@
         </div>
 
         <h3 class="mt-8 mb-2 text-lg font-semibold">
+          Sales by Store
+        </h3>
+        <ul class="mb-6 list-disc ps-5">
+          <li
+            v-for="s in storeSales"
+            :key="s.store"
+          >
+            {{ s.store }} - {{ s.count }} sold (${{ s.revenue.toFixed(2) }})
+          </li>
+          <li
+            v-if="!storeSales.length"
+            class="list-none text-gray-500"
+          >
+            No data
+          </li>
+        </ul>
+
+        <h3 class="mb-2 text-lg font-semibold">
           Top Sold Items
         </h3>
         <ul class="mb-6 list-disc ps-5">
@@ -220,6 +238,26 @@ const topSoldItems = computed(() => {
   return Array.from(map, ([name, count]) => ({ name, count }))
     .sort((a, b) => b.count - a.count)
     .slice(0, 5);
+});
+
+function parsePrice(price: string | undefined): number {
+  if (!price) return 0;
+  const num = parseFloat(String(price).replace(/[^0-9.]/g, ''));
+  return isNaN(num) ? 0 : num;
+}
+
+const storeSales = computed(() => {
+  const map = new Map<string, { count: number; revenue: number }>();
+  for (const item of filteredSoldItems.value) {
+    const key = item.location || 'Unknown';
+    const count = totalSoldFor(item);
+    const price = parsePrice(item.price);
+    const entry = map.get(key) || { count: 0, revenue: 0 };
+    entry.count += count;
+    entry.revenue += count * price;
+    map.set(key, entry);
+  }
+  return Array.from(map, ([store, data]) => ({ store, ...data }));
 });
 
 const chartCanvas = ref<HTMLCanvasElement | null>(null);

--- a/src/components/StatsDisplay.vue
+++ b/src/components/StatsDisplay.vue
@@ -10,7 +10,7 @@
     </div>
     <div
       class="bg-white rounded-xl shadow-md p-4 text-center cursor-pointer"
-      @click="goToDashboard"
+      @click="emit('show-sold-details')"
     >
       <h2 class="text-sm text-gray-500 uppercase">
         Sold
@@ -67,17 +67,12 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue';
-import { useRouter } from 'vue-router';
 import type { Stats } from '../utils/stats';
 
 const props = defineProps<{
   stats: Stats;
 }>();
-
-const router = useRouter();
-const goToDashboard = () => {
-  router.push('/dashboard');
-};
+const emit = defineEmits(['show-sold-details']);
 
 const showOutstanding = ref(false);
 const toggleOutstanding = () => {


### PR DESCRIPTION
## Summary
- Open detailed sales modal from StatsDisplay
- Show sales by store with month and item filters
- Add store sales summary and chart in sold details

## Testing
- `npm run test:unit`
- `npm run test:e2e` *(fails: missing Xvfb dependency)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd7c6cb4b88320bc92c00d74684db5