### PR TITLE
refactor: use Supabase for store invites

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,19 +2,17 @@
 # with your own Supabase credentials and hCaptcha site key.
 VITE_SUPABASE_URL=
 VITE_SUPABASE_KEY=
-VITE_HCAPTCHA_SITEKEY=
 
-
-# Supabase service role for Netlify functions
+# Server-side Supabase credentials for Netlify functions
 SUPABASE_URL=
 SUPABASE_SERVICE_ROLE_KEY=
 
-# Mail server (SES) configuration
+VITE_HCAPTCHA_SITEKEY=
 
-SES_HOST=
-SES_PORT=465
-SES_USER=
-SES_PASS=
+# Mail server configuration
 MAIL_FROM=
 MAIL_TO=
+
+# AWS SES configuration for transactional emails
+AWS_REGION=
 

--- a/netlify/functions/inviteStore.cjs
+++ b/netlify/functions/inviteStore.cjs
@@ -1,5 +1,4 @@
-
-const { SESv2Client, SendEmailCommand } = require('@aws-sdk/client-sesv2');
+const { createClient } = require('@supabase/supabase-js');
 
 const baseHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -13,62 +12,62 @@ exports.handler = async (event) => {
     return { statusCode: 200, headers: baseHeaders, body: '' };
   }
   if (event.httpMethod !== 'POST') {
-    return { statusCode: 405, headers: baseHeaders, body: JSON.stringify({ error: 'Method not allowed' }) };
+    return {
+      statusCode: 405,
+      headers: baseHeaders,
+      body: JSON.stringify({ ok: false, error: 'Method not allowed' }),
+    };
   }
 
   try {
-    const { email, name, signupUrl } = JSON.parse(event.body || '{}');
-
+    const { email, signupUrl } = JSON.parse(event.body || '{}');
     if (!email || !signupUrl) {
-
       return {
         statusCode: 400,
         headers: baseHeaders,
-        body: JSON.stringify({ error: 'Missing required fields' }),
+        body: JSON.stringify({ ok: false, error: 'Missing required fields' }),
       };
     }
 
+    const supabaseUrl = process.env.SUPABASE_URL;
+    const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
-    const region = process.env.AWS_REGION || process.env.SES_REGION;
-    const from = process.env.MAIL_FROM;
-    const template = process.env.SES_TEMPLATE_INVITE || 'store-invite';
-
-    if (!region || !from) {
+    if (!supabaseUrl || !supabaseKey) {
+      console.error('Missing Supabase configuration');
       return {
         statusCode: 500,
         headers: baseHeaders,
+        body: JSON.stringify({ ok: false, error: 'Server misconfigured' }),
+      };
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseKey);
+    const { data, error } = await supabase.auth.admin.inviteUserByEmail(email, {
+      redirectTo: signupUrl,
+      data: { role: 'store', roles: ['store'] },
+    });
+
+    if (error) {
+      return {
+        statusCode: error.status || 500,
+        headers: baseHeaders,
         body: JSON.stringify({
-          error: 'User invite failed',
-          detail: 'Missing AWS configuration',
+          ok: false,
+          error: error.name || 'INVITE_FAILED',
+          detail: error.message,
         }),
       };
     }
 
-    const ses = new SESv2Client({ region });
-
-    const command = new SendEmailCommand({
-      FromEmailAddress: from,
-      Destination: { ToAddresses: [email] },
-      Content: {
-        Template: {
-          TemplateName: template,
-          TemplateData: JSON.stringify({ name: name || '', signupUrl }),
-        },
-      },
-    });
-
-    await ses.send(command);
-    
     return {
       statusCode: 200,
       headers: baseHeaders,
-      body: JSON.stringify({ ok: true }),
+      body: JSON.stringify({ ok: true, user: data?.user }),
     };
   } catch (err) {
     console.error('Error sending invite:', err);
-    const status = err.name === 'AccessDeniedException' ? 403 : 500;
     return {
-      statusCode: status,
+      statusCode: 500,
       headers: baseHeaders,
       body: JSON.stringify({
         ok: false,

--- a/netlify/functions/notifyItemSold.cjs
+++ b/netlify/functions/notifyItemSold.cjs
@@ -16,7 +16,7 @@ exports.handler = async (event) => {
     return {
       statusCode: 405,
       headers: baseHeaders,
-      body: JSON.stringify({ error: 'Method not allowed' }),
+      body: JSON.stringify({ ok: false, error: 'Method not allowed' }),
     };
   }
 
@@ -26,44 +26,41 @@ exports.handler = async (event) => {
       return {
         statusCode: 400,
         headers: baseHeaders,
-        body: JSON.stringify({ error: 'Missing required fields' }),
+        body: JSON.stringify({ ok: false, error: 'Missing required fields' }),
       };
     }
 
-    const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
-    const serviceKey =
-      process.env.SUPABASE_SERVICE_ROLE_KEY ||
-      process.env.VITE_SUPABASE_SERVICE_ROLE_KEY ||
-      process.env.VITE_SUPABASE_KEY;
-    if (!supabaseUrl || !serviceKey) {
+    const supabaseUrl = process.env.SUPABASE_URL;
+    const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!supabaseUrl || !supabaseKey) {
+      console.error('Missing Supabase configuration');
       return {
         statusCode: 500,
         headers: baseHeaders,
-        body: JSON.stringify({ error: 'Missing Supabase configuration' }),
+        body: JSON.stringify({ ok: false, error: 'Server misconfigured' }),
       };
     }
 
-    const supabase = createClient(supabaseUrl, serviceKey);
+    const supabase = createClient(supabaseUrl, supabaseKey);
     const authHeader = event.headers.authorization || event.headers.Authorization;
     if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      return { statusCode: 401, headers: baseHeaders, body: JSON.stringify({ error: 'Unauthorized' }) };
+      return { statusCode: 401, headers: baseHeaders, body: JSON.stringify({ ok: false, error: 'Unauthorized' }) };
     }
     const accessToken = authHeader.split(' ')[1];
     const { data: userData, error: userError } = await supabase.auth.getUser(accessToken);
     const caller = userData?.user;
     const roles = require('./_auth.cjs').getRoles(caller);
     if (userError || !caller || !roles.includes('store')) {
-      
-      return { statusCode: 403, headers: baseHeaders, body: JSON.stringify({ error: 'Forbidden' }) };
+      return { statusCode: 403, headers: baseHeaders, body: JSON.stringify({ ok: false, error: 'Forbidden' }) };
     }
 
-    const region = process.env.AWS_REGION || process.env.SES_REGION;
+    const region = process.env.AWS_REGION;
     const from = process.env.MAIL_FROM;
     if (!region || !from) {
       return {
         statusCode: 500,
         headers: baseHeaders,
-        body: JSON.stringify({ error: 'Missing mail server configuration' }),
+        body: JSON.stringify({ ok: false, error: 'Missing mail server configuration' }),
       };
     }
 

--- a/netlify/functions/sendEmail.cjs
+++ b/netlify/functions/sendEmail.cjs
@@ -9,10 +9,13 @@ const baseHeaders = {
 };
 
 exports.handler = async (event) => {
-  if (event.httpMethod === 'OPTIONS') {
+  const method = (event.httpMethod || '').toUpperCase();
+
+  if (method === 'OPTIONS') {
     return { statusCode: 200, headers: baseHeaders, body: '' };
   }
-  if (event.httpMethod !== 'POST') {
+
+  if (method !== 'POST') {
     return { statusCode: 405, headers: baseHeaders, body: JSON.stringify({ error: 'Method not allowed' }) };
   }
 
@@ -27,7 +30,7 @@ exports.handler = async (event) => {
       };
     }
 
-    const region = process.env.AWS_REGION || process.env.SES_REGION;
+    const region = process.env.AWS_REGION;
     const from = process.env.MAIL_FROM;
     const to = process.env.MAIL_TO;
 


### PR DESCRIPTION
## Summary
- replace AWS SES invite flow with Supabase admin client
- require explicit Supabase service-role credentials for invites and sold notifications
- simplify environment example by removing unused SES variables

## Testing
- `npm run lint`
- `npm run test:unit -- --run`
- `npm run test:e2e` *(fails: missing dependency Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d7cacba0832099926d35415e199c