### PR TITLE
feat: add folder support for notes

### DIFF
--- a/docs/MIGRATION_CREATE_FOLDERS.sql
+++ b/docs/MIGRATION_CREATE_FOLDERS.sql
@@ -1,0 +1,28 @@
+-- Migration script to create folders table and link notes
+create table if not exists public.folders (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id) on delete cascade,
+  name text not null,
+  created_at timestamptz default now()
+);
+
+alter table public.folders enable row level security;
+
+drop policy if exists "Individuals can delete their own folders" on public.folders;
+create policy "Individuals can delete their own folders" on public.folders
+  for delete using ((select auth.uid()) = user_id);
+
+drop policy if exists "Individuals can insert their own folders" on public.folders;
+create policy "Individuals can insert their own folders" on public.folders
+  for insert with check ((select auth.uid()) = user_id);
+
+drop policy if exists "Individuals can update their own folders" on public.folders;
+create policy "Individuals can update their own folders" on public.folders
+  for update using ((select auth.uid()) = user_id);
+
+drop policy if exists "Individuals can view their own folders" on public.folders;
+create policy "Individuals can view their own folders" on public.folders
+  for select using ((select auth.uid()) = user_id);
+
+alter table if exists public.notes
+  add column if not exists folder_id uuid references public.folders(id) on delete cascade;

--- a/docs/SUPABASE_FOLDERS_SETUP.sql
+++ b/docs/SUPABASE_FOLDERS_SETUP.sql
@@ -1,0 +1,25 @@
+-- Setup script for per-user folders
+create table if not exists public.folders (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id) on delete cascade,
+  name text not null,
+  created_at timestamptz default now()
+);
+
+alter table public.folders enable row level security;
+
+drop policy if exists "Individuals can delete their own folders" on public.folders;
+create policy "Individuals can delete their own folders" on public.folders
+  for delete using ((select auth.uid()) = user_id);
+
+drop policy if exists "Individuals can insert their own folders" on public.folders;
+create policy "Individuals can insert their own folders" on public.folders
+  for insert with check ((select auth.uid()) = user_id);
+
+drop policy if exists "Individuals can update their own folders" on public.folders;
+create policy "Individuals can update their own folders" on public.folders
+  for update using ((select auth.uid()) = user_id);
+
+drop policy if exists "Individuals can view their own folders" on public.folders;
+create policy "Individuals can view their own folders" on public.folders
+  for select using ((select auth.uid()) = user_id);

--- a/docs/SUPABASE_NOTES_SETUP.sql
+++ b/docs/SUPABASE_NOTES_SETUP.sql
@@ -2,6 +2,7 @@
 create table if not exists public.notes (
   id uuid primary key default gen_random_uuid(),
   user_id uuid references auth.users(id) on delete cascade,
+  folder_id uuid references public.folders(id) on delete cascade,
   title text not null,
   item_type text,
   sku text,

--- a/src/types/folder.ts
+++ b/src/types/folder.ts
@@ -1,0 +1,23 @@
+export interface Folder {
+  id: string;
+  /** User that owns the folder */
+  userId?: string;
+  name: string;
+  createdAt: string;
+}
+
+export interface FolderRecord {
+  id: string;
+  user_id?: string;
+  name: string;
+  created_at: string;
+}
+
+export function mapRecordToFolder(record: FolderRecord): Folder {
+  return {
+    id: String(record.id),
+    userId: record.user_id,
+    name: record.name,
+    createdAt: record.created_at,
+  };
+}

--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -1,5 +1,7 @@
 export interface Note {
   id: string;
+  /** Folder that this note belongs to */
+  folderId?: string;
   title: string;
   itemType: string;
   sku: string;
@@ -14,6 +16,7 @@ export interface Note {
 export interface NoteRecord {
   id: string;
   user_id?: string;
+  folder_id?: string | null;
   title: string;
   item_type?: string | null;
   sku?: string | null;
@@ -27,6 +30,7 @@ export interface NoteRecord {
 export function mapRecordToNote(record: NoteRecord): Note {
   return {
     id: String(record.id),
+    folderId: record.folder_id || undefined,
     title: record.title,
     itemType: record.item_type || '',
     sku: record.sku || '',


### PR DESCRIPTION
## Summary
- add folderId to notes and records
- introduce folders table with setup and migration scripts
- implement folder navigation, selection, and filtering in notes UI

## Testing
- `npm run test:unit` *(passed)*
- `npm run test:e2e` *(fails: Install Xvfb and run Cypress again)*

------
https://chatgpt.com/codex/tasks/task_e_68c2dd3e5f3c83208150e71339b1d3ca