### PR TITLE
feat: add folder support for notes

### DIFF
--- a/docs/MIGRATION_CREATE_FOLDERS.sql
+++ b/docs/MIGRATION_CREATE_FOLDERS.sql
@@ -1,0 +1,28 @@
+-- Migration script to create folders table and link notes
+create table if not exists public.folders (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id) on delete cascade,
+  name text not null,
+  created_at timestamptz default now()
+);
+
+alter table public.folders enable row level security;
+
+drop policy if exists "Individuals can delete their own folders" on public.folders;
+create policy "Individuals can delete their own folders" on public.folders
+  for delete using ((select auth.uid()) = user_id);
+
+drop policy if exists "Individuals can insert their own folders" on public.folders;
+create policy "Individuals can insert their own folders" on public.folders
+  for insert with check ((select auth.uid()) = user_id);
+
+drop policy if exists "Individuals can update their own folders" on public.folders;
+create policy "Individuals can update their own folders" on public.folders
+  for update using ((select auth.uid()) = user_id);
+
+drop policy if exists "Individuals can view their own folders" on public.folders;
+create policy "Individuals can view their own folders" on public.folders
+  for select using ((select auth.uid()) = user_id);
+
+alter table if exists public.notes
+  add column if not exists folder_id uuid references public.folders(id) on delete cascade;

--- a/docs/SUPABASE_FOLDERS_SETUP.sql
+++ b/docs/SUPABASE_FOLDERS_SETUP.sql
@@ -1,0 +1,25 @@
+-- Setup script for per-user folders
+create table if not exists public.folders (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id) on delete cascade,
+  name text not null,
+  created_at timestamptz default now()
+);
+
+alter table public.folders enable row level security;
+
+drop policy if exists "Individuals can delete their own folders" on public.folders;
+create policy "Individuals can delete their own folders" on public.folders
+  for delete using ((select auth.uid()) = user_id);
+
+drop policy if exists "Individuals can insert their own folders" on public.folders;
+create policy "Individuals can insert their own folders" on public.folders
+  for insert with check ((select auth.uid()) = user_id);
+
+drop policy if exists "Individuals can update their own folders" on public.folders;
+create policy "Individuals can update their own folders" on public.folders
+  for update using ((select auth.uid()) = user_id);
+
+drop policy if exists "Individuals can view their own folders" on public.folders;
+create policy "Individuals can view their own folders" on public.folders
+  for select using ((select auth.uid()) = user_id);

--- a/docs/SUPABASE_NOTES_SETUP.sql
+++ b/docs/SUPABASE_NOTES_SETUP.sql
@@ -2,6 +2,7 @@
 create table if not exists public.notes (
   id uuid primary key default gen_random_uuid(),
   user_id uuid references auth.users(id) on delete cascade,
+  folder_id uuid references public.folders(id) on delete cascade,
   title text not null,
   item_type text,
   sku text,

--- a/src/NotesPage.vue
+++ b/src/NotesPage.vue
@@ -1,7 +1,37 @@
 <template>
   <div class="min-h-screen bg-gray-100 text-gray-900 font-sans">
-    <div class="max-w-screen-md mx-auto p-4 flex flex-col gap-6">
-      <div class="flex items-center justify-between">
+    <div class="max-w-screen-lg mx-auto p-4">
+      <div class="flex gap-6">
+        <aside class="w-48">
+          <div class="bg-white rounded shadow p-4 mb-4">
+            <h2 class="text-lg font-semibold mb-2">Folders</h2>
+            <ul>
+              <li
+                :class="['cursor-pointer mb-1', activeFolderId === null ? 'font-bold' : '']"
+                @click="activeFolderId = null"
+              >
+                All Notes
+              </li>
+              <li
+                v-for="folder in folders"
+                :key="folder.id"
+                :class="['cursor-pointer mb-1', folder.id === activeFolderId ? 'font-bold' : '']"
+                @click="activeFolderId = folder.id"
+              >
+                {{ folder.name }}
+              </li>
+            </ul>
+            <button
+              type="button"
+              class="text-sm text-blue-600 hover:underline mt-2"
+              @click="createFolder"
+            >
+              + New Folder
+            </button>
+          </div>
+        </aside>
+        <div class="flex-1 flex flex-col gap-6">
+          <div class="flex items-center justify-between">
         <router-link
           to="/app"
           class="text-blue-600 hover:underline"
@@ -32,6 +62,28 @@
               type="text"
               required
             >
+          </div>
+          <div class="mb-4">
+            <label
+              for="folder"
+              class="block text-sm mb-1"
+            >Folder</label>
+            <select
+              id="folder"
+              v-model="form.folderId"
+              class="w-full px-3 py-2 border rounded"
+            >
+              <option value="">
+                --Select Folder--
+              </option>
+              <option
+                v-for="folder in folders"
+                :key="folder.id"
+                :value="folder.id"
+              >
+                {{ folder.name }}
+              </option>
+            </select>
           </div>
           <div class="mb-4">
             <label
@@ -217,6 +269,8 @@
       </div>
     </div>
   </div>
+  </div>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -224,9 +278,11 @@ import { onMounted, ref, computed } from 'vue'
 import { supabase } from './supabaseClient'
 import type { Item } from './types/item'
 import { mapRecordToNote, type Note, type NoteRecord } from './types/note'
+import { mapRecordToFolder, type Folder, type FolderRecord } from './types/folder'
 
 const form = ref({
   title: '',
+  folderId: '',
   itemType: '',
   sku: '',
   store: '',
@@ -236,6 +292,8 @@ const form = ref({
 })
 
 const notes = ref<Note[]>([])
+const folders = ref<Folder[]>([])
+const activeFolderId = ref<string | null>(null)
 const itemOptions = ref<string[]>([])
 const skuOptions = ref<string[]>([])
 const storeOptions = ref<string[]>([])
@@ -245,10 +303,93 @@ const showForm = ref(false)
 const editingNoteId = ref<string | null>(null)
 
 onMounted(async () => {
+  await loadFolders()
   await loadNotes()
   await fetchOptions()
   checkReminders()
 })
+
+async function loadFolders() {
+  const { data: sessionData } = await supabase.auth.getSession()
+  const user = sessionData.session?.user
+  isAuthenticated.value = !!user
+
+  if (!user) {
+    const raw = localStorage.getItem('folders')
+    folders.value = raw ? JSON.parse(raw) : []
+    return
+  }
+
+  const { data, error } = await supabase
+    .from<FolderRecord>('folders')
+    .select('*')
+    .eq('user_id', user.id)
+
+  if (error) {
+    console.error('Failed to load folders from Supabase:', error)
+    alert('Could not load folders from the database.')
+    return
+  }
+
+  folders.value = data ? data.map(mapRecordToFolder) : []
+  saveFolders()
+}
+
+function saveFolders() {
+  if (isAuthenticated.value) {
+    return
+  }
+  try {
+    localStorage.setItem('folders', JSON.stringify(folders.value))
+  } catch (error) {
+    console.error('Failed to save folders:', error)
+    if (error instanceof DOMException && error.name === 'QuotaExceededError') {
+      try {
+        localStorage.removeItem('folders')
+        localStorage.setItem('folders', JSON.stringify(folders.value))
+      } catch (retryError) {
+        console.error('Retry after clearing storage failed:', retryError)
+        alert('Browser storage limit exceeded. Folders were not saved.')
+      }
+    }
+  }
+}
+
+async function createFolder() {
+  const name = prompt('Folder name?')
+  if (!name) return
+
+  const { data: sessionData } = await supabase.auth.getSession()
+  const user = sessionData.session?.user
+
+  if (user) {
+    const { data: inserted, error } = await supabase
+      .from('folders')
+      .insert([{ user_id: user.id, name }])
+      .select('*')
+      .single()
+    if (error) {
+      console.error('Failed to create folder in Supabase:', error)
+      alert('Failed to create folder in the database.')
+      return
+    }
+    const folder = mapRecordToFolder(inserted as FolderRecord)
+    folders.value.push(folder)
+    saveFolders()
+    activeFolderId.value = folder.id
+    return
+  }
+
+  const id = crypto.randomUUID()
+  const folder: Folder = {
+    id,
+    name,
+    createdAt: new Date().toISOString(),
+  }
+  folders.value.push(folder)
+  saveFolders()
+  activeFolderId.value = id
+}
 
 async function loadNotes() {
 
@@ -332,7 +473,16 @@ function handleImage(e: Event) {
 }
 
 function resetForm() {
-  form.value = { title: '', itemType: '', sku: '', store: '', text: '', image: null, date: '' }
+  form.value = {
+    title: '',
+    folderId: activeFolderId.value || '',
+    itemType: '',
+    sku: '',
+    store: '',
+    text: '',
+    image: null,
+    date: ''
+  }
 }
 
 function startNewNote() {
@@ -345,6 +495,7 @@ function startEdit(note: Note) {
   editingNoteId.value = note.id
   form.value = {
     title: note.title,
+    folderId: note.folderId || '',
     itemType: note.itemType,
     sku: note.sku,
     store: note.store,
@@ -396,6 +547,7 @@ async function saveNote() {
         const { error } = await supabase
           .from('notes')
           .update({
+            folder_id: form.value.folderId || null,
             title: form.value.title,
             item_type: form.value.itemType || null,
             sku: form.value.sku || null,
@@ -414,6 +566,7 @@ async function saveNote() {
       }
 
       existing.title = form.value.title
+      existing.folderId = form.value.folderId || undefined
       existing.itemType = form.value.itemType
       existing.sku = form.value.sku
       existing.store = form.value.store
@@ -445,6 +598,7 @@ async function saveNote() {
           .insert([
             {
               user_id: user.id,
+              folder_id: form.value.folderId || null,
               title: form.value.title,
               item_type: form.value.itemType || null,
               sku: form.value.sku || null,
@@ -472,6 +626,7 @@ async function saveNote() {
       const createdAt = new Date().toISOString()
       const note: Note = {
         id: tempId,
+        folderId: form.value.folderId || undefined,
         title: form.value.title,
         itemType: form.value.itemType,
         sku: form.value.sku,
@@ -500,7 +655,9 @@ async function saveNote() {
 }
 
 const sortedNotes = computed(() =>
-  [...notes.value].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+  [...notes.value]
+    .filter(n => !activeFolderId.value || n.folderId === activeFolderId.value)
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
 )
 
 function formatDate(dateStr: string) {

--- a/src/types/folder.ts
+++ b/src/types/folder.ts
@@ -1,0 +1,23 @@
+export interface Folder {
+  id: string;
+  /** User that owns the folder */
+  userId?: string;
+  name: string;
+  createdAt: string;
+}
+
+export interface FolderRecord {
+  id: string;
+  user_id?: string;
+  name: string;
+  created_at: string;
+}
+
+export function mapRecordToFolder(record: FolderRecord): Folder {
+  return {
+    id: String(record.id),
+    userId: record.user_id,
+    name: record.name,
+    createdAt: record.created_at,
+  };
+}

--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -1,5 +1,7 @@
 export interface Note {
   id: string;
+  /** Folder that this note belongs to */
+  folderId?: string;
   title: string;
   itemType: string;
   sku: string;
@@ -14,6 +16,7 @@ export interface Note {
 export interface NoteRecord {
   id: string;
   user_id?: string;
+  folder_id?: string | null;
   title: string;
   item_type?: string | null;
   sku?: string | null;
@@ -27,6 +30,7 @@ export interface NoteRecord {
 export function mapRecordToNote(record: NoteRecord): Note {
   return {
     id: String(record.id),
+    folderId: record.folder_id || undefined,
     title: record.title,
     itemType: record.item_type || '',
     sku: record.sku || '',


### PR DESCRIPTION
## Summary
- add folderId to notes and records
- introduce folders table with setup and migration scripts
- implement folder navigation, selection, and filtering in notes UI
- close unbalanced divs in NotesPage to fix build error

## Testing
- `npm run test:unit -- --run`
- `xvfb-run -a npm run test:e2e` *(fails: missing libatk-1.0.so.0)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c2dd3e5f3c83208150e71339b1d3ca