### PR TITLE
feat: refresh dashboard styling with tailus themer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-palette="trust" data-shade="900" data-rounded="large">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/Uglyico.ico" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
                 "@aws-sdk/client-sesv2": "^3.873.0",
                 "@hcaptcha/vue3-hcaptcha": "^1.3.0",
                 "@supabase/supabase-js": "^2.49.8",
+                "@tailus/themer": "^0.1.8",
                 "@tailwindcss/postcss": "^4.1.10",
                 "chart.js": "^4.4.1",
                 "chartjs-plugin-zoom": "^2.2.0",
@@ -2624,6 +2625,22 @@
                 "@supabase/realtime-js": "2.11.2",
                 "@supabase/storage-js": "2.7.1"
             }
+        },
+        "node_modules/@tailus/themer": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/@tailus/themer/-/themer-0.1.8.tgz",
+            "integrity": "sha512-p9rXKk4TYnUo9jzCHKLFohq7NBuUiBgWNmQSvqAG7ak0kWbpNffg9OS/WRmcGojmILBxaUFhbkxLoyY+UtVJSg==",
+            "license": "MIT",
+            "dependencies": {
+                "@tailus/themer-plugins": "^0.1.3",
+                "tailwind-variants": "^0.2.1"
+            }
+        },
+        "node_modules/@tailus/themer-plugins": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@tailus/themer-plugins/-/themer-plugins-0.1.3.tgz",
+            "integrity": "sha512-r+R0Q1IolPs74TH3+0ZjABqgqvQJXNMMQQQl7pZ7tNGsF2C0C5OpGzRmAC98+vIPYjpj0/rJTK1yq6894vQzRg==",
+            "license": "MIT"
         },
         "node_modules/@tailwindcss/node": {
             "version": "4.1.10",
@@ -8454,6 +8471,32 @@
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/tailwind-merge": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
+            "integrity": "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/dcastil"
+            }
+        },
+        "node_modules/tailwind-variants": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/tailwind-variants/-/tailwind-variants-0.2.1.tgz",
+            "integrity": "sha512-2xmhAf4UIc3PijOUcJPA1LP4AbxhpcHuHM2C26xM0k81r0maAO6uoUSHl3APmvHZcY5cZCY/bYuJdfFa4eGoaw==",
+            "license": "MIT",
+            "dependencies": {
+                "tailwind-merge": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=16.x",
+                "pnpm": ">=7.x"
+            },
+            "peerDependencies": {
+                "tailwindcss": "*"
+            }
         },
         "node_modules/tailwindcss": {
             "version": "4.1.10",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "@aws-sdk/client-sesv2": "^3.873.0",
         "@hcaptcha/vue3-hcaptcha": "^1.3.0",
         "@supabase/supabase-js": "^2.49.8",
+        "@tailus/themer": "^0.1.8",
         "@tailwindcss/postcss": "^4.1.10",
         "chart.js": "^4.4.1",
         "chartjs-plugin-zoom": "^2.2.0",

--- a/public/main.css
+++ b/public/main.css
@@ -8,9 +8,7 @@
       "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
       "Courier New", monospace;
-    --color-red-50: oklch(97.1% 0.013 17.38);
     --color-red-100: oklch(93.6% 0.032 17.717);
-    --color-red-400: oklch(70.4% 0.191 22.216);
     --color-red-500: oklch(63.7% 0.237 25.331);
     --color-red-600: oklch(57.7% 0.245 27.325);
     --color-red-700: oklch(50.5% 0.213 27.518);
@@ -37,6 +35,7 @@
     --color-gray-700: oklch(37.3% 0.034 259.733);
     --color-gray-800: oklch(27.8% 0.033 256.848);
     --color-gray-900: oklch(21% 0.034 264.665);
+    --color-gray-950: oklch(13% 0.028 261.692);
     --color-neutral-200: oklch(92.2% 0 0);
     --color-neutral-300: oklch(87% 0 0);
     --color-neutral-400: oklch(70.8% 0 0);
@@ -49,10 +48,14 @@
     --color-white: #fff;
     --spacing: 0.25rem;
     --breakpoint-md: 48rem;
-    --breakpoint-xl: 80rem;
+    --breakpoint-lg: 64rem;
     --container-sm: 24rem;
     --container-md: 28rem;
-    --container-2xl: 42rem;
+    --container-lg: 32rem;
+    --container-xl: 36rem;
+    --container-3xl: 48rem;
+    --container-5xl: 64rem;
+    --container-7xl: 80rem;
     --text-xs: 0.75rem;
     --text-xs--line-height: calc(1 / 0.75);
     --text-sm: 0.875rem;
@@ -65,20 +68,19 @@
     --text-2xl--line-height: calc(2 / 1.5);
     --text-3xl: 1.875rem;
     --text-3xl--line-height: calc(2.25 / 1.875);
-    --text-4xl: 2.25rem;
-    --text-4xl--line-height: calc(2.5 / 2.25);
-    --text-6xl: 3.75rem;
-    --text-6xl--line-height: 1;
     --font-weight-normal: 400;
     --font-weight-medium: 500;
     --font-weight-semibold: 600;
     --font-weight-bold: 700;
     --font-weight-extrabold: 800;
     --tracking-wider: 0.05em;
+    --leading-tight: 1.25;
     --radius-sm: 0.25rem;
     --radius-md: 0.375rem;
     --radius-lg: 0.5rem;
     --radius-xl: 0.75rem;
+    --radius-2xl: 1rem;
+    --radius-3xl: 1.5rem;
     --animate-spin: spin 1s linear infinite;
     --blur-sm: 8px;
     --default-transition-duration: 150ms;
@@ -294,6 +296,17 @@
   .visible {
     visibility: visible;
   }
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+  }
   .absolute {
     position: absolute;
   }
@@ -315,20 +328,20 @@
   .top-2 {
     top: calc(var(--spacing) * 2);
   }
+  .top-6 {
+    top: calc(var(--spacing) * 6);
+  }
   .right-0 {
     right: calc(var(--spacing) * 0);
   }
   .right-2 {
     right: calc(var(--spacing) * 2);
   }
-  .bottom-0 {
-    bottom: calc(var(--spacing) * 0);
+  .right-6 {
+    right: calc(var(--spacing) * 6);
   }
   .left-0 {
     left: calc(var(--spacing) * 0);
-  }
-  .z-0 {
-    z-index: 0;
   }
   .z-10 {
     z-index: 10;
@@ -366,14 +379,29 @@
   .mx-auto {
     margin-inline: auto;
   }
+  .my-2 {
+    margin-block: calc(var(--spacing) * 2);
+  }
   .mt-1 {
     margin-top: calc(var(--spacing) * 1);
   }
   .mt-2 {
     margin-top: calc(var(--spacing) * 2);
   }
+  .mt-3 {
+    margin-top: calc(var(--spacing) * 3);
+  }
   .mt-4 {
     margin-top: calc(var(--spacing) * 4);
+  }
+  .mt-5 {
+    margin-top: calc(var(--spacing) * 5);
+  }
+  .mt-6 {
+    margin-top: calc(var(--spacing) * 6);
+  }
+  .mt-8 {
+    margin-top: calc(var(--spacing) * 8);
   }
   .mt-10 {
     margin-top: calc(var(--spacing) * 10);
@@ -402,14 +430,11 @@
   .mb-6 {
     margin-bottom: calc(var(--spacing) * 6);
   }
-  .mb-8 {
-    margin-bottom: calc(var(--spacing) * 8);
-  }
   .ml-1 {
     margin-left: calc(var(--spacing) * 1);
   }
-  .ml-4 {
-    margin-left: calc(var(--spacing) * 4);
+  .ml-2 {
+    margin-left: calc(var(--spacing) * 2);
   }
   .block {
     display: block;
@@ -420,14 +445,36 @@
   .grid {
     display: grid;
   }
+  .inline-flex {
+    display: inline-flex;
+  }
   .table {
     display: table;
+  }
+  .size-4 {
+    width: calc(var(--spacing) * 4);
+    height: calc(var(--spacing) * 4);
+  }
+  .size-5 {
+    width: calc(var(--spacing) * 5);
+    height: calc(var(--spacing) * 5);
+  }
+  .size-10 {
+    width: calc(var(--spacing) * 10);
+    height: calc(var(--spacing) * 10);
+  }
+  .size-14 {
+    width: calc(var(--spacing) * 14);
+    height: calc(var(--spacing) * 14);
+  }
+  .h-2 {
+    height: calc(var(--spacing) * 2);
   }
   .h-4 {
     height: calc(var(--spacing) * 4);
   }
-  .h-8 {
-    height: calc(var(--spacing) * 8);
+  .h-5 {
+    height: calc(var(--spacing) * 5);
   }
   .h-12 {
     height: calc(var(--spacing) * 12);
@@ -444,14 +491,23 @@
   .h-64 {
     height: calc(var(--spacing) * 64);
   }
+  .h-\[3\.5rem\] {
+    height: 3.5rem;
+  }
   .h-full {
     height: 100%;
+  }
+  .h-px {
+    height: 1px;
   }
   .max-h-40 {
     max-height: calc(var(--spacing) * 40);
   }
   .max-h-\[90vh\] {
     max-height: 90vh;
+  }
+  .max-h-\[320px\] {
+    max-height: 320px;
   }
   .max-h-screen {
     max-height: 100vh;
@@ -462,8 +518,8 @@
   .w-4 {
     width: calc(var(--spacing) * 4);
   }
-  .w-8 {
-    width: calc(var(--spacing) * 8);
+  .w-5 {
+    width: calc(var(--spacing) * 5);
   }
   .w-12 {
     width: calc(var(--spacing) * 12);
@@ -474,23 +530,35 @@
   .w-24 {
     width: calc(var(--spacing) * 24);
   }
-  .w-48 {
-    width: calc(var(--spacing) * 48);
-  }
-  .w-56 {
-    width: calc(var(--spacing) * 56);
+  .w-64 {
+    width: calc(var(--spacing) * 64);
   }
   .w-80 {
     width: calc(var(--spacing) * 80);
   }
+  .w-96 {
+    width: calc(var(--spacing) * 96);
+  }
+  .w-auto {
+    width: auto;
+  }
   .w-full {
     width: 100%;
   }
-  .max-w-2xl {
-    max-width: var(--container-2xl);
+  .max-w-3xl {
+    max-width: var(--container-3xl);
+  }
+  .max-w-5xl {
+    max-width: var(--container-5xl);
+  }
+  .max-w-7xl {
+    max-width: var(--container-7xl);
   }
   .max-w-full {
     max-width: 100%;
+  }
+  .max-w-lg {
+    max-width: var(--container-lg);
   }
   .max-w-md {
     max-width: var(--container-md);
@@ -498,14 +566,20 @@
   .max-w-screen {
     max-width: 100vw;
   }
+  .max-w-screen-lg {
+    max-width: var(--breakpoint-lg);
+  }
   .max-w-screen-md {
     max-width: var(--breakpoint-md);
   }
-  .max-w-screen-xl {
-    max-width: var(--breakpoint-xl);
-  }
   .max-w-sm {
     max-width: var(--container-sm);
+  }
+  .max-w-xl {
+    max-width: var(--container-xl);
+  }
+  .min-w-\[150px\] {
+    min-width: 150px;
   }
   .min-w-full {
     min-width: 100%;
@@ -525,6 +599,12 @@
   .cursor-pointer {
     cursor: pointer;
   }
+  .snap-x {
+    scroll-snap-type: x var(--tw-scroll-snap-strictness);
+  }
+  .snap-start {
+    scroll-snap-align: start;
+  }
   .grid-cols-1 {
     grid-template-columns: repeat(1, minmax(0, 1fr));
   }
@@ -540,8 +620,14 @@
   .flex-wrap {
     flex-wrap: wrap;
   }
+  .items-baseline {
+    align-items: baseline;
+  }
   .items-center {
     align-items: center;
+  }
+  .items-start {
+    align-items: flex-start;
   }
   .justify-between {
     justify-content: space-between;
@@ -551,6 +637,9 @@
   }
   .justify-end {
     justify-content: flex-end;
+  }
+  .gap-1 {
+    gap: calc(var(--spacing) * 1);
   }
   .gap-2 {
     gap: calc(var(--spacing) * 2);
@@ -564,6 +653,16 @@
   .gap-6 {
     gap: calc(var(--spacing) * 6);
   }
+  .gap-8 {
+    gap: calc(var(--spacing) * 8);
+  }
+  .space-y-1 {
+    :where(& > :not(:last-child)) {
+      --tw-space-y-reverse: 0;
+      margin-block-start: calc(calc(var(--spacing) * 1) * var(--tw-space-y-reverse));
+      margin-block-end: calc(calc(var(--spacing) * 1) * calc(1 - var(--tw-space-y-reverse)));
+    }
+  }
   .space-y-2 {
     :where(& > :not(:last-child)) {
       --tw-space-y-reverse: 0;
@@ -576,6 +675,13 @@
       --tw-space-y-reverse: 0;
       margin-block-start: calc(calc(var(--spacing) * 3) * var(--tw-space-y-reverse));
       margin-block-end: calc(calc(var(--spacing) * 3) * calc(1 - var(--tw-space-y-reverse)));
+    }
+  }
+  .space-y-8 {
+    :where(& > :not(:last-child)) {
+      --tw-space-y-reverse: 0;
+      margin-block-start: calc(calc(var(--spacing) * 8) * var(--tw-space-y-reverse));
+      margin-block-end: calc(calc(var(--spacing) * 8) * calc(1 - var(--tw-space-y-reverse)));
     }
   }
   .space-x-2 {
@@ -601,10 +707,18 @@
       border-bottom-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
     }
   }
+  .divide-\[--ui-border-color\] {
+    :where(& > :not(:last-child)) {
+      border-color: --ui-border-color;
+    }
+  }
   .divide-gray-200 {
     :where(& > :not(:last-child)) {
       border-color: var(--color-gray-200);
     }
+  }
+  .overflow-auto {
+    overflow: auto;
   }
   .overflow-hidden {
     overflow: hidden;
@@ -618,6 +732,12 @@
   .rounded {
     border-radius: 0.25rem;
   }
+  .rounded-2xl {
+    border-radius: var(--radius-2xl);
+  }
+  .rounded-3xl {
+    border-radius: var(--radius-3xl);
+  }
   .rounded-full {
     border-radius: calc(infinity * 1px);
   }
@@ -626,6 +746,9 @@
   }
   .rounded-md {
     border-radius: var(--radius-md);
+  }
+  .rounded-none {
+    border-radius: 0;
   }
   .rounded-sm {
     border-radius: var(--radius-sm);
@@ -641,9 +764,16 @@
     border-style: var(--tw-border-style);
     border-width: 4px;
   }
-  .border-t {
-    border-top-style: var(--tw-border-style);
-    border-top-width: 1px;
+  .border-b {
+    border-bottom-style: var(--tw-border-style);
+    border-bottom-width: 1px;
+  }
+  .border-dashed {
+    --tw-border-style: dashed;
+    border-style: dashed;
+  }
+  .border-\[--ui-border-color\] {
+    border-color: --ui-border-color;
   }
   .border-gray-200 {
     border-color: var(--color-gray-200);
@@ -654,14 +784,32 @@
   .border-purple-500 {
     border-color: var(--color-purple-500);
   }
-  .border-red-400 {
-    border-color: var(--color-red-400);
+  .border-transparent {
+    border-color: transparent;
   }
   .border-white {
     border-color: var(--color-white);
   }
   .border-t-transparent {
     border-top-color: transparent;
+  }
+  .bg-\[--overlay-bg\] {
+    background-color: --overlay-bg;
+  }
+  .bg-\[--ui-bg\] {
+    background-color: --ui-bg;
+  }
+  .bg-\[--ui-bg\]\/80 {
+    background-color: color-mix(in oklab, --ui-bg 80%, transparent);
+  }
+  .bg-\[--ui-bg\]\/95 {
+    background-color: color-mix(in oklab, --ui-bg 95%, transparent);
+  }
+  .bg-\[--ui-border-color\] {
+    background-color: --ui-border-color;
+  }
+  .bg-\[--ui-soft-bg\] {
+    background-color: --ui-soft-bg;
   }
   .bg-black {
     background-color: var(--color-black);
@@ -702,18 +850,31 @@
   .bg-white {
     background-color: var(--color-white);
   }
-  .bg-white\/70 {
-    background-color: color-mix(in srgb, #fff 70%, transparent);
+  .bg-white\/30 {
+    background-color: color-mix(in srgb, #fff 30%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
-      background-color: color-mix(in oklab, var(--color-white) 70%, transparent);
+      background-color: color-mix(in oklab, var(--color-white) 30%, transparent);
+    }
+  }
+  .bg-white\/90 {
+    background-color: color-mix(in srgb, #fff 90%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-white) 90%, transparent);
     }
   }
   .bg-yellow-100 {
     background-color: var(--color-yellow-100);
   }
+  .bg-gradient-to-br {
+    --tw-gradient-position: to bottom right in oklab;
+    background-image: linear-gradient(var(--tw-gradient-stops));
+  }
   .bg-gradient-to-r {
     --tw-gradient-position: to right in oklab;
     background-image: linear-gradient(var(--tw-gradient-stops));
+  }
+  .bg-\[radial-gradient\(circle_at_top\,theme\(colors\.white\/0\.35\)\,transparent_55\%\)\] {
+    background-image: radial-gradient(circle at top,color-mix(in oklab, #fff 35%, transparent),transparent 55%);
   }
   .from-purple-600 {
     --tw-gradient-from: var(--color-purple-600);
@@ -731,8 +892,8 @@
     -o-object-fit: cover;
        object-fit: cover;
   }
-  .p-1 {
-    padding: calc(var(--spacing) * 1);
+  .p-3 {
+    padding: calc(var(--spacing) * 3);
   }
   .p-4 {
     padding: calc(var(--spacing) * 4);
@@ -752,8 +913,14 @@
   .px-4 {
     padding-inline: calc(var(--spacing) * 4);
   }
+  .px-5 {
+    padding-inline: calc(var(--spacing) * 5);
+  }
   .px-6 {
     padding-inline: calc(var(--spacing) * 6);
+  }
+  .px-10 {
+    padding-inline: calc(var(--spacing) * 10);
   }
   .py-1 {
     padding-block: calc(var(--spacing) * 1);
@@ -761,23 +928,38 @@
   .py-2 {
     padding-block: calc(var(--spacing) * 2);
   }
+  .py-2\.5 {
+    padding-block: calc(var(--spacing) * 2.5);
+  }
   .py-3 {
     padding-block: calc(var(--spacing) * 3);
+  }
+  .py-4 {
+    padding-block: calc(var(--spacing) * 4);
+  }
+  .py-6 {
+    padding-block: calc(var(--spacing) * 6);
   }
   .py-8 {
     padding-block: calc(var(--spacing) * 8);
   }
-  .pt-6 {
-    padding-top: calc(var(--spacing) * 6);
+  .py-10 {
+    padding-block: calc(var(--spacing) * 10);
   }
-  .pb-6 {
-    padding-bottom: calc(var(--spacing) * 6);
+  .py-12 {
+    padding-block: calc(var(--spacing) * 12);
+  }
+  .pb-4 {
+    padding-bottom: calc(var(--spacing) * 4);
   }
   .text-center {
     text-align: center;
   }
   .text-left {
     text-align: left;
+  }
+  .text-right {
+    text-align: right;
   }
   .font-sans {
     font-family: var(--font-sans);
@@ -789,10 +971,6 @@
   .text-3xl {
     font-size: var(--text-3xl);
     line-height: var(--tw-leading, var(--text-3xl--line-height));
-  }
-  .text-4xl {
-    font-size: var(--text-4xl);
-    line-height: var(--tw-leading, var(--text-4xl--line-height));
   }
   .text-lg {
     font-size: var(--text-lg);
@@ -810,8 +988,15 @@
     font-size: var(--text-xs);
     line-height: var(--tw-leading, var(--text-xs--line-height));
   }
+  .text-\[2\.475rem\] {
+    font-size: 2.475rem;
+  }
   .text-\[10px\] {
     font-size: 10px;
+  }
+  .leading-tight {
+    --tw-leading: var(--leading-tight);
+    line-height: var(--leading-tight);
   }
   .font-bold {
     --tw-font-weight: var(--font-weight-bold);
@@ -825,9 +1010,21 @@
     --tw-font-weight: var(--font-weight-medium);
     font-weight: var(--font-weight-medium);
   }
+  .font-normal {
+    --tw-font-weight: var(--font-weight-normal);
+    font-weight: var(--font-weight-normal);
+  }
   .font-semibold {
     --tw-font-weight: var(--font-weight-semibold);
     font-weight: var(--font-weight-semibold);
+  }
+  .tracking-\[0\.2em\] {
+    --tw-tracking: 0.2em;
+    letter-spacing: 0.2em;
+  }
+  .tracking-\[0\.3em\] {
+    --tw-tracking: 0.3em;
+    letter-spacing: 0.3em;
   }
   .tracking-wider {
     --tw-tracking: var(--tracking-wider);
@@ -835,6 +1032,9 @@
   }
   .whitespace-nowrap {
     white-space: nowrap;
+  }
+  .text-\[--body-text-color\] {
+    color: --body-text-color;
   }
   .text-blue-500 {
     color: var(--color-blue-500);
@@ -872,17 +1072,29 @@
   .text-purple-500 {
     color: var(--color-purple-500);
   }
+  .text-purple-600 {
+    color: var(--color-purple-600);
+  }
   .text-red-500 {
     color: var(--color-red-500);
   }
   .text-red-600 {
     color: var(--color-red-600);
   }
-  .text-red-700 {
-    color: var(--color-red-700);
-  }
   .text-white {
     color: var(--color-white);
+  }
+  .text-white\/70 {
+    color: color-mix(in srgb, #fff 70%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      color: color-mix(in oklab, var(--color-white) 70%, transparent);
+    }
+  }
+  .text-white\/80 {
+    color: color-mix(in srgb, #fff 80%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      color: color-mix(in oklab, var(--color-white) 80%, transparent);
+    }
   }
   .text-yellow-800 {
     color: var(--color-yellow-800);
@@ -896,11 +1108,22 @@
   .opacity-25 {
     opacity: 25%;
   }
+  .opacity-70 {
+    opacity: 70%;
+  }
   .opacity-75 {
     opacity: 75%;
   }
   .shadow {
     --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-2xl {
+    --tw-shadow: 0 25px 50px -12px var(--tw-shadow-color, rgb(0 0 0 / 0.25));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-inner {
+    --tw-shadow: inset 0 2px 4px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.05));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
   .shadow-lg {
@@ -911,6 +1134,10 @@
     --tw-shadow: 0 4px 6px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 2px 4px -2px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
+  .shadow-none {
+    --tw-shadow: 0 0 #0000;
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
   .shadow-sm {
     --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
@@ -918,6 +1145,24 @@
   .shadow-xl {
     --tw-shadow: 0 20px 25px -5px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 8px 10px -6px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-gray-950\/5 {
+    --tw-shadow-color: color-mix(in srgb, oklch(13% 0.028 261.692) 5%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-shadow-color: color-mix(in oklab, color-mix(in oklab, var(--color-gray-950) 5%, transparent) var(--tw-shadow-alpha), transparent);
+    }
+  }
+  .shadow-gray-950\/10 {
+    --tw-shadow-color: color-mix(in srgb, oklch(13% 0.028 261.692) 10%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-shadow-color: color-mix(in oklab, color-mix(in oklab, var(--color-gray-950) 10%, transparent) var(--tw-shadow-alpha), transparent);
+    }
+  }
+  .shadow-gray-950\/20 {
+    --tw-shadow-color: color-mix(in srgb, oklch(13% 0.028 261.692) 20%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-shadow-color: color-mix(in oklab, color-mix(in oklab, var(--color-gray-950) 20%, transparent) var(--tw-shadow-alpha), transparent);
+    }
   }
   .outline-hidden {
     --tw-outline-style: none;
@@ -931,8 +1176,17 @@
     outline-style: var(--tw-outline-style);
     outline-width: 1px;
   }
+  .blur {
+    --tw-blur: blur(8px);
+    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+  }
   .filter {
     filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+  }
+  .backdrop-blur {
+    --tw-backdrop-blur: blur(8px);
+    -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+    backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
   }
   .backdrop-blur-sm {
     --tw-backdrop-blur: blur(var(--blur-sm));
@@ -943,6 +1197,52 @@
     transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, backdrop-filter, display, visibility, content-visibility, overlay, pointer-events;
     transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
     transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+  .transition-all {
+    transition-property: all;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+  .transition-transform {
+    transition-property: transform, translate, scale, rotate;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+  .duration-300 {
+    --tw-duration: 300ms;
+    transition-duration: 300ms;
+  }
+  .duration-500 {
+    --tw-duration: 500ms;
+    transition-duration: 500ms;
+  }
+  .group-hover\:translate-x-1 {
+    &:is(:where(.group):hover *) {
+      @media (hover: hover) {
+        --tw-translate-x: calc(var(--spacing) * 1);
+        translate: var(--tw-translate-x) var(--tw-translate-y);
+      }
+    }
+  }
+  .last\:border-b-0 {
+    &:last-child {
+      border-bottom-style: var(--tw-border-style);
+      border-bottom-width: 0px;
+    }
+  }
+  .hover\:bg-\[--ui-bg\] {
+    &:hover {
+      @media (hover: hover) {
+        background-color: --ui-bg;
+      }
+    }
+  }
+  .hover\:bg-\[--ui-soft-bg\] {
+    &:hover {
+      @media (hover: hover) {
+        background-color: --ui-soft-bg;
+      }
+    }
   }
   .hover\:bg-blue-600 {
     &:hover {
@@ -986,13 +1286,6 @@
       }
     }
   }
-  .hover\:bg-red-50 {
-    &:hover {
-      @media (hover: hover) {
-        background-color: var(--color-red-50);
-      }
-    }
-  }
   .hover\:text-blue-700 {
     &:hover {
       @media (hover: hover) {
@@ -1004,6 +1297,13 @@
     &:hover {
       @media (hover: hover) {
         color: var(--color-green-700);
+      }
+    }
+  }
+  .hover\:text-purple-700 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-purple-700);
       }
     }
   }
@@ -1025,6 +1325,22 @@
     &:hover {
       @media (hover: hover) {
         opacity: 90%;
+      }
+    }
+  }
+  .hover\:shadow-lg {
+    &:hover {
+      @media (hover: hover) {
+        --tw-shadow: 0 10px 15px -3px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 4px 6px -4px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+        box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+      }
+    }
+  }
+  .hover\:brightness-110 {
+    &:hover {
+      @media (hover: hover) {
+        --tw-brightness: brightness(110%);
+        filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
       }
     }
   }
@@ -1050,6 +1366,31 @@
       outline-style: none;
     }
   }
+  .focus-visible\:outline {
+    &:focus-visible {
+      outline-style: var(--tw-outline-style);
+      outline-width: 1px;
+    }
+  }
+  .focus-visible\:outline-2 {
+    &:focus-visible {
+      outline-style: var(--tw-outline-style);
+      outline-width: 2px;
+    }
+  }
+  .focus-visible\:outline-offset-2 {
+    &:focus-visible {
+      outline-offset: 2px;
+    }
+  }
+  .focus-visible\:outline-white\/70 {
+    &:focus-visible {
+      outline-color: color-mix(in srgb, #fff 70%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        outline-color: color-mix(in oklab, var(--color-white) 70%, transparent);
+      }
+    }
+  }
   .active\:scale-95 {
     &:active {
       --tw-scale-x: 95%;
@@ -1063,9 +1404,14 @@
       opacity: 50%;
     }
   }
-  .sm\:grid-cols-5 {
+  .sm\:grid-cols-2 {
     @media (width >= 40rem) {
-      grid-template-columns: repeat(5, minmax(0, 1fr));
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+  .sm\:grid-cols-3 {
+    @media (width >= 40rem) {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
     }
   }
   .sm\:flex-row {
@@ -1083,53 +1429,60 @@
       align-items: flex-end;
     }
   }
-  .sm\:space-y-0 {
+  .sm\:justify-between {
     @media (width >= 40rem) {
-      :where(& > :not(:last-child)) {
-        --tw-space-y-reverse: 0;
-        margin-block-start: calc(calc(var(--spacing) * 0) * var(--tw-space-y-reverse));
-        margin-block-end: calc(calc(var(--spacing) * 0) * calc(1 - var(--tw-space-y-reverse)));
-      }
+      justify-content: space-between;
     }
   }
-  .sm\:space-x-2 {
+  .sm\:justify-start {
     @media (width >= 40rem) {
-      :where(& > :not(:last-child)) {
-        --tw-space-x-reverse: 0;
-        margin-inline-start: calc(calc(var(--spacing) * 2) * var(--tw-space-x-reverse));
-        margin-inline-end: calc(calc(var(--spacing) * 2) * calc(1 - var(--tw-space-x-reverse)));
-      }
+      justify-content: flex-start;
     }
   }
-  .sm\:space-x-4 {
+  .sm\:p-10 {
     @media (width >= 40rem) {
-      :where(& > :not(:last-child)) {
-        --tw-space-x-reverse: 0;
-        margin-inline-start: calc(calc(var(--spacing) * 4) * var(--tw-space-x-reverse));
-        margin-inline-end: calc(calc(var(--spacing) * 4) * calc(1 - var(--tw-space-x-reverse)));
-      }
+      padding: calc(var(--spacing) * 10);
     }
   }
-  .md\:h-72 {
-    @media (width >= 48rem) {
-      height: calc(var(--spacing) * 72);
+  .sm\:px-8 {
+    @media (width >= 40rem) {
+      padding-inline: calc(var(--spacing) * 8);
     }
   }
-  .md\:w-72 {
+  .md\:grid-cols-4 {
     @media (width >= 48rem) {
-      width: calc(var(--spacing) * 72);
+      grid-template-columns: repeat(4, minmax(0, 1fr));
     }
   }
-  .md\:text-6xl {
+  .md\:px-24 {
     @media (width >= 48rem) {
-      font-size: var(--text-6xl);
-      line-height: var(--tw-leading, var(--text-6xl--line-height));
+      padding-inline: calc(var(--spacing) * 24);
     }
   }
   .md\:text-xl {
     @media (width >= 48rem) {
       font-size: var(--text-xl);
       line-height: var(--tw-leading, var(--text-xl--line-height));
+    }
+  }
+  .md\:text-\[4\.125rem\] {
+    @media (width >= 48rem) {
+      font-size: 4.125rem;
+    }
+  }
+  .lg\:grid-cols-2 {
+    @media (width >= 64rem) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+  .lg\:px-12 {
+    @media (width >= 64rem) {
+      padding-inline: calc(var(--spacing) * 12);
+    }
+  }
+  .xl\:grid-cols-4 {
+    @media (width >= 80rem) {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
     }
   }
 }
@@ -1495,8 +1848,8 @@
   }
 }
 body {
-  background-color: var(--color-gray-100);
-  color: var(--color-gray-800);
+  background-color: --ui-soft-bg;
+  color: var(--body-text-color);
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -1505,13 +1858,22 @@ button {
   transition-property: all;
   transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
   transition-duration: var(--tw-duration, var(--default-transition-duration));
-  --tw-duration: 150ms;
-  transition-duration: 150ms;
+  --tw-duration: 200ms;
+  transition-duration: 200ms;
 }
 img {
-  border-radius: 0.25rem;
-  --tw-shadow: 0 4px 6px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 2px 4px -2px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+  border-radius: var(--card-radius);
+  --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
   box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  --tw-shadow-color: color-mix(in srgb, oklch(13% 0.028 261.692) 10%, transparent);
+  @supports (color: color-mix(in lab, red, red)) {
+    --tw-shadow-color: color-mix(in oklab, color-mix(in oklab, var(--color-gray-950) 10%, transparent) var(--tw-shadow-alpha), transparent);
+  }
+}
+@property --tw-scroll-snap-strictness {
+  syntax: "*";
+  inherits: false;
+  initial-value: proximity;
 }
 @property --tw-space-y-reverse {
   syntax: "*";
@@ -1574,6 +1936,10 @@ img {
   syntax: "<length-percentage>";
   inherits: false;
   initial-value: 100%;
+}
+@property --tw-leading {
+  syntax: "*";
+  inherits: false;
 }
 @property --tw-font-weight {
   syntax: "*";
@@ -1742,6 +2108,25 @@ img {
   syntax: "*";
   inherits: false;
 }
+@property --tw-duration {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-translate-x {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+@property --tw-translate-y {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+@property --tw-translate-z {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
 @property --tw-scale-x {
   syntax: "*";
   inherits: false;
@@ -1757,10 +2142,6 @@ img {
   inherits: false;
   initial-value: 1;
 }
-@property --tw-duration {
-  syntax: "*";
-  inherits: false;
-}
 @keyframes spin {
   to {
     transform: rotate(360deg);
@@ -1769,6 +2150,7 @@ img {
 @layer properties {
   @supports ((-webkit-hyphens: none) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color:rgb(from red r g b)))) {
     *, ::before, ::after, ::backdrop {
+      --tw-scroll-snap-strictness: proximity;
       --tw-space-y-reverse: 0;
       --tw-space-x-reverse: 0;
       --tw-divide-y-reverse: 0;
@@ -1782,6 +2164,7 @@ img {
       --tw-gradient-from-position: 0%;
       --tw-gradient-via-position: 50%;
       --tw-gradient-to-position: 100%;
+      --tw-leading: initial;
       --tw-font-weight: initial;
       --tw-tracking: initial;
       --tw-shadow: 0 0 #0000;
@@ -1821,10 +2204,13 @@ img {
       --tw-backdrop-opacity: initial;
       --tw-backdrop-saturate: initial;
       --tw-backdrop-sepia: initial;
+      --tw-duration: initial;
+      --tw-translate-x: 0;
+      --tw-translate-y: 0;
+      --tw-translate-z: 0;
       --tw-scale-x: 1;
       --tw-scale-y: 1;
       --tw-scale-z: 1;
-      --tw-duration: initial;
     }
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,89 +1,210 @@
 <template>
-  <div class="min-h-screen bg-gray-100 text-gray-900 font-sans">
-    <div class="flex flex-col gap-6 px-4 pt-6 pb-6 max-w-screen-xl mx-auto overflow-y-auto">
-      <div class="flex items-center justify-between mb-8">
-        <div class="flex items-center space-x-2 flex-1">
-          <img
-            src="https://ielukqallxtceqmobmvp.supabase.co/storage/v1/object/public/images//uglysmall.png"
-            alt="ConsignTracker logo"
-            class="h-[3.5rem] w-auto object-contain"
-            @error="(e) => (e.target as HTMLImageElement).src = '/ugly_192px.png'"
-          >
-          <h1 class="text-3xl font-bold leading-tight">
-            ConsignTracker
-            <span class="block text-sm font-normal">by UglyStuff.ca</span>
-          </h1>
-        </div>
-        <div
-          ref="menuRef"
-          class="relative"
-        >
-          <button
-            class="bg-blue-500 text-white font-semibold px-4 py-2 rounded-md hover:bg-blue-600 active:scale-95 transition"
-            @click="toggleMenu"
-          >
-            ☰ Menu
-          </button>
+  <div class="min-h-screen bg-[--ui-soft-bg] font-sans">
+    <div class="relative mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-8 px-4 py-10 sm:px-8 lg:px-12">
+      <div class="rounded-3xl border border-[--ui-border-color] bg-[--ui-bg]/80 p-6 shadow-sm shadow-gray-950/10 backdrop-blur">
+        <div class="flex flex-wrap items-center justify-between gap-6">
+          <div class="flex flex-1 items-center gap-4">
+            <div class="flex size-14 items-center justify-center rounded-2xl bg-[--ui-soft-bg] shadow-inner shadow-gray-950/10">
+              <img
+                src="https://ielukqallxtceqmobmvp.supabase.co/storage/v1/object/public/images//uglysmall.png"
+                alt="ConsignTracker logo"
+                class="h-12 w-auto rounded-none object-contain shadow-none"
+                @error="(e) => (e.target as HTMLImageElement).src = '/ugly_192px.png'"
+              >
+            </div>
+            <div>
+              <h1 class="text-3xl font-semibold text-title">
+                ConsignTracker
+              </h1>
+              <p class="text-sm text-caption">
+                by UglyStuff.ca
+              </p>
+            </div>
+          </div>
           <div
-            v-if="showMenu"
-            class="absolute right-0 mt-2 w-56 bg-white rounded-md shadow-lg z-50"
+            ref="menuRef"
+            class="relative"
           >
-            <div class="px-4 py-2 text-xs font-semibold text-gray-500">
-              Tools
+            <button
+              type="button"
+              class="inline-flex items-center gap-2 rounded-btn border border-[--ui-border-color] bg-[--ui-soft-bg] px-4 py-2 text-sm font-semibold text-title shadow-sm shadow-gray-950/5 transition hover:border-primary-300 hover:text-primary-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+              @click="toggleMenu"
+            >
+              <svg
+                class="size-4"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+              >
+                <path d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+              <span>Menu</span>
+            </button>
+            <div
+              v-if="showMenu"
+              class="absolute right-0 z-50 mt-3 w-64 rounded-2xl border border-[--ui-border-color] bg-[--ui-bg] p-3 shadow-xl shadow-gray-950/20"
+            >
+              <div class="px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-caption">
+                Tools
+              </div>
+              <button
+                class="flex w-full items-center justify-between rounded-card px-3 py-2 text-sm font-medium text-[--body-text-color] transition hover:bg-[--ui-soft-bg]"
+                @click="openExport"
+              >
+                <span>Export Data</span>
+                <svg
+                  class="size-4 text-caption"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M5 12h14M13 6l6 6-6 6" />
+                </svg>
+              </button>
+              <button
+                class="mt-1 flex w-full items-center justify-between rounded-card px-3 py-2 text-sm font-medium text-[--body-text-color] transition hover:bg-[--ui-soft-bg]"
+                @click="goTo('/notes')"
+              >
+                <span>Notes</span>
+                <svg
+                  class="size-4 text-caption"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M5 12h14M13 6l6 6-6 6" />
+                </svg>
+              </button>
+              <div class="my-2 h-px bg-[--ui-border-color]" />
+              <div class="px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-caption">
+                Settings
+              </div>
+              <button
+                class="flex w-full items-center justify-between rounded-card px-3 py-2 text-sm font-medium text-[--body-text-color] transition hover:bg-[--ui-soft-bg]"
+                @click="goTo('/settings')"
+              >
+                <span>Settings</span>
+                <svg
+                  class="size-4 text-caption"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M5 12h14M13 6l6 6-6 6" />
+                </svg>
+              </button>
+              <div class="my-2 h-px bg-[--ui-border-color]" />
+              <div class="px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-caption">
+                Contact
+              </div>
+              <button
+                class="flex w-full items-center justify-between rounded-card px-3 py-2 text-sm font-medium text-[--body-text-color] transition hover:bg-[--ui-soft-bg]"
+                @click="reportIssue"
+              >
+                <span>Report an Issue</span>
+                <svg
+                  class="size-4 text-caption"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M5 12h14M13 6l6 6-6 6" />
+                </svg>
+              </button>
+              <button
+                class="mt-1 flex w-full items-center justify-between rounded-card px-3 py-2 text-sm font-medium text-[--body-text-color] transition hover:bg-[--ui-soft-bg]"
+                @click="requestFeature"
+              >
+                <span>Request a Feature</span>
+                <svg
+                  class="size-4 text-caption"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M5 12h14M13 6l6 6-6 6" />
+                </svg>
+              </button>
+              <div class="my-2 h-px bg-[--ui-border-color]" />
+              <div class="px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-caption">
+                Sign Out
+              </div>
+              <button
+                class="flex w-full items-center justify-between rounded-card px-3 py-2 text-sm font-medium text-danger-600 transition hover:bg-danger-50"
+                @click="handleSignOut"
+              >
+                <span>Sign Out</span>
+                <svg
+                  class="size-4"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M5 12h14M13 6l6 6-6 6" />
+                </svg>
+              </button>
             </div>
-            <button
-              class="block w-full text-left px-4 py-2 hover:bg-gray-100"
-              @click="openExport"
-            >
-              Export Data
-            </button>
-            <button
-              class="block w-full text-left px-4 py-2 hover:bg-gray-100"
-              @click="goTo('/notes')"
-            >
-              Notes
-            </button>
-            <div class="px-4 py-2 text-xs font-semibold text-gray-500 border-t">
-              Settings
-            </div>
-            <button
-              class="block w-full text-left px-4 py-2 hover:bg-gray-100"
-              @click="goTo('/settings')"
-            >
-              Settings
-            </button>
-            <div class="px-4 py-2 text-xs font-semibold text-gray-500 border-t">
-              Contact
-            </div>
-            <button
-              class="block w-full text-left px-4 py-2 hover:bg-gray-100"
-              @click="reportIssue"
-            >
-              Report an Issue
-            </button>
-            <button
-              class="block w-full text-left px-4 py-2 hover:bg-gray-100"
-              @click="requestFeature"
-            >
-              Request a Feature
-            </button>
-            <div class="px-4 py-2 text-xs font-semibold text-gray-500 border-t">
-              Sign Out
-            </div>
-            <button
-              class="block w-full text-left px-4 py-2 text-red-600 hover:bg-red-50"
-              @click="handleSignOut"
-            >
-              Sign Out
-            </button>
           </div>
         </div>
       </div>
 
-      <StatsDisplay
-        :stats="currentStats"
-        @show-sold-details="showSoldDetails = true"
-      />
+      <section class="rounded-3xl border border-[--ui-border-color] bg-[--ui-bg]/80 p-6 shadow-sm shadow-gray-950/10 backdrop-blur">
+        <div class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 class="text-2xl font-semibold text-title">
+              Dashboard Snapshot
+            </h2>
+            <p class="text-sm text-caption">
+              Monitor sales, payments, and outstanding totals at a glance.
+            </p>
+          </div>
+          <button
+            type="button"
+            class="inline-flex items-center gap-2 text-sm font-medium text-primary-600 transition hover:text-primary-500"
+            @click="showSoldDetails = true"
+          >
+            View sold breakdown
+            <svg
+              class="size-4"
+              fill="none"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+            >
+              <path d="M5 12h14M13 6l6 6-6 6" />
+            </svg>
+          </button>
+        </div>
+        <div class="mt-6">
+          <StatsDisplay
+            :stats="currentStats"
+            @show-sold-details="showSoldDetails = true"
+          />
+        </div>
+      </section>
 
       <SoldDetailsModal
         v-if="showSoldDetails"
@@ -93,7 +214,7 @@
 
       <div
         v-if="lowStockItems.length"
-        class="bg-yellow-100 text-yellow-800 px-4 py-2 rounded mb-4"
+        class="mb-4 flex items-center gap-3 rounded-card border border-warning-200 bg-warning-50 px-4 py-3 text-sm text-warning-700 shadow-sm shadow-warning-500/10"
       >
         ⚠️ {{ lowStockItems.length }} item(s) need restocking
       </div>
@@ -102,14 +223,14 @@
       <!-- Show server error if any -->
       <div
         v-if="serverError"
-        class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4"
+        class="mb-4 flex items-center gap-3 rounded-card border border-danger-200 bg-danger-50 px-4 py-3 text-sm text-danger-700 shadow-sm shadow-danger-500/10"
       >
         {{ serverError }}
       </div>
     
       <div
         v-if="showForm && !editingItem"
-        class="fixed inset-0 flex items-center justify-center bg-black/30 backdrop-blur-sm z-40"
+        class="fixed inset-0 z-40 flex items-center justify-center bg-[--overlay-bg] backdrop-blur-sm"
         @click.self="showForm = false"
       >
         <ItemForm
@@ -120,7 +241,7 @@
 
       <div
         v-if="editingItem"
-        class="fixed inset-0 flex items-center justify-center bg-black/30 backdrop-blur-sm z-40"
+        class="fixed inset-0 z-40 flex items-center justify-center bg-[--overlay-bg] backdrop-blur-sm"
         @click.self="editingItem = null"
       >
         <EditItemForm
@@ -132,67 +253,81 @@
     
       <div
         v-if="!showForm"
-        class="mb-6"
+        class="mb-6 flex justify-end sm:justify-start"
       >
         <button
-          class="bg-gradient-to-r from-purple-600 to-pink-500 text-white font-semibold px-4 py-2 rounded-md shadow hover:opacity-90 active:scale-95 transition"
+          type="button"
+          class="inline-flex items-center gap-2 rounded-btn bg-gradient-to-r from-primary-600 via-primary-500 to-secondary-500 px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-primary-950/20 transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70"
           @click="showForm = true"
         >
+          <svg
+            class="size-4"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+          >
+            <path d="M12 5v14M5 12h14" />
+          </svg>
           Add New Item
         </button>
       </div>
     
-      <div class="mb-4 flex flex-col sm:flex-row sm:items-center sm:space-x-4 space-y-2 sm:space-y-0 flex-wrap">
-        <label
-          for="view"
-          class="mr-2 text-sm text-gray-700"
-        >View:</label>
-        <select
-          id="view"
-          v-model="layout"
-          class="px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 text-sm"
-        >
-          <option value="grid">
-            Grid
-          </option>
-          <option value="table">
-            Table
-          </option>
-        </select>
-        <template v-if="layout === 'grid'">
+      <div class="flex flex-col flex-wrap items-center gap-3 rounded-3xl border border-[--ui-border-color] bg-[--ui-bg] p-4 shadow-sm shadow-gray-950/10 sm:flex-row sm:justify-between">
+        <div class="flex flex-wrap items-center gap-3">
           <label
-            for="columns"
-            class="ml-4 mr-2 text-sm text-gray-700"
-          >Columns:</label>
+            for="view"
+            class="text-sm font-medium text-caption"
+          >View</label>
           <select
-            id="columns"
-            v-model.number="columns"
-            class="px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 text-sm"
+            id="view"
+            v-model="layout"
+            class="rounded-btn border border-[--ui-border-color] bg-[--ui-soft-bg] px-3 py-2 text-sm text-[--body-text-color] shadow-sm shadow-gray-950/5 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
           >
-            <option :value="1">
-              1 column
+            <option value="grid">
+              Grid
             </option>
-            <option :value="2">
-              2 columns
-            </option>
-            <option :value="3">
-              3 columns
+            <option value="table">
+              Table
             </option>
           </select>
-        </template>
+          <template v-if="layout === 'grid'">
+            <label
+              for="columns"
+              class="text-sm font-medium text-caption"
+            >Columns</label>
+            <select
+              id="columns"
+              v-model.number="columns"
+              class="rounded-btn border border-[--ui-border-color] bg-[--ui-soft-bg] px-3 py-2 text-sm text-[--body-text-color] shadow-sm shadow-gray-950/5 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+            >
+              <option :value="1">
+                1 column
+              </option>
+              <option :value="2">
+                2 columns
+              </option>
+              <option :value="3">
+                3 columns
+              </option>
+            </select>
+          </template>
+        </div>
       </div>
 
 
-      <div class="mb-4 flex flex-col sm:flex-row sm:items-end sm:space-x-2 space-y-2 sm:space-y-0">
+      <div class="flex flex-col gap-3 rounded-3xl border border-[--ui-border-color] bg-[--ui-bg] p-4 shadow-sm shadow-gray-950/10 sm:flex-row sm:items-center sm:justify-between">
         <input
           v-model="searchQuery"
           type="text"
           placeholder="Search"
-          class="flex-1 px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
+          class="flex-1 rounded-btn border border-[--ui-border-color] bg-[--ui-soft-bg] px-4 py-2 text-sm text-[--body-text-color] shadow-sm shadow-gray-950/5 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
         >
         <button
           v-if="searchQuery"
-          class="border border-gray-300 rounded px-2 py-1 bg-gray-100"
+          class="inline-flex items-center gap-2 rounded-btn border border-[--ui-border-color] bg-[--ui-bg] px-3 py-2 text-sm font-medium text-caption transition hover:border-primary-300 hover:text-primary-600"
           @click="clearSearch"
         >
           Clear
@@ -201,7 +336,7 @@
 
       <div
         v-if="isLoading"
-        class="text-center py-8"
+        class="rounded-3xl border border-[--ui-border-color] bg-[--ui-bg] py-12 text-center text-sm text-caption shadow-inner shadow-gray-950/5"
       >
         Loading items...
       </div>

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -8,18 +8,20 @@
 
 
 body {
-  @apply bg-gray-100 text-gray-800;
+  @apply bg-[--ui-soft-bg];
+  color: var(--body-text-color);
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 button {
-  @apply transition-all duration-150;
+  @apply transition-all duration-200;
 }
 
 img {
-  @apply rounded shadow-md;
+  border-radius: var(--card-radius);
+  @apply shadow-sm shadow-gray-950/10;
 }
 
 

--- a/src/components/SoldDetailsModal.vue
+++ b/src/components/SoldDetailsModal.vue
@@ -1,23 +1,46 @@
 <template>
   <div
-    class="fixed inset-0 flex items-center justify-center bg-black/30 backdrop-blur-sm z-50"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-[--overlay-bg] px-4 py-6 backdrop-blur-sm"
     @click.self="emit('close')"
   >
-    <div class="bg-white rounded-lg p-4 w-full max-w-4xl max-h-[90vh] overflow-y-auto relative">
+    <div class="relative w-full max-w-5xl overflow-hidden rounded-3xl border border-[--ui-border-color] bg-[--ui-bg] p-6 shadow-2xl shadow-gray-950/20 sm:p-10">
       <button
-        class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
+        type="button"
+        class="absolute right-6 top-6 inline-flex size-10 items-center justify-center rounded-full border border-transparent bg-[--ui-soft-bg] text-caption transition hover:bg-[--ui-bg] hover:text-title focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
         @click="emit('close')"
       >
-        ✕
+        <span class="sr-only">Close</span>
+        <svg
+          class="size-5"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+        >
+          <path d="M6 6l12 12M6 18 18 6" />
+        </svg>
       </button>
-      <h2 class="mb-4 text-xl font-semibold">
-        Sold Items Details
-      </h2>
-      <div class="p-0">
-        <div class="flex flex-wrap gap-4 mb-6">
+
+      <div class="max-w-3xl">
+        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-primary-600">
+          Sales Overview
+        </p>
+        <h2 class="mt-2 text-3xl font-semibold text-title">
+          Sold Items Details
+        </h2>
+        <p class="mt-3 text-sm text-caption">
+          Analyze performance across months, stores, and categories to understand how inventory is moving.
+        </p>
+      </div>
+
+      <div class="mt-8 grid gap-4 sm:grid-cols-3">
+        <label class="flex flex-col gap-2 text-sm text-caption">
+          <span class="font-medium text-caption">Month</span>
           <select
             v-model="selectedMonth"
-            class="select select-bordered"
+            class="w-full rounded-btn border border-[--ui-border-color] bg-[--ui-soft-bg] px-4 py-2 text-sm text-[--body-text-color] shadow-sm shadow-gray-950/5 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
           >
             <option value="">
               All Months
@@ -30,9 +53,12 @@
               {{ formatMonth(m) }}
             </option>
           </select>
+        </label>
+        <label class="flex flex-col gap-2 text-sm text-caption">
+          <span class="font-medium text-caption">Store</span>
           <select
             v-model="selectedStore"
-            class="select select-bordered"
+            class="w-full rounded-btn border border-[--ui-border-color] bg-[--ui-soft-bg] px-4 py-2 text-sm text-[--body-text-color] shadow-sm shadow-gray-950/5 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
           >
             <option value="">
               All Stores
@@ -45,9 +71,12 @@
               {{ s }}
             </option>
           </select>
+        </label>
+        <label class="flex flex-col gap-2 text-sm text-caption">
+          <span class="font-medium text-caption">Category</span>
           <select
             v-model="selectedCategory"
-            class="select select-bordered"
+            class="w-full rounded-btn border border-[--ui-border-color] bg-[--ui-soft-bg] px-4 py-2 text-sm text-[--body-text-color] shadow-sm shadow-gray-950/5 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
           >
             <option value="">
               All Categories
@@ -60,40 +89,44 @@
               {{ c }}
             </option>
           </select>
-        </div>
+        </label>
+      </div>
 
-        <h3 class="mb-2 text-lg font-semibold">
-          Sold Items
-        </h3>
-        <div class="overflow-x-auto">
-          <table class="table w-full">
-            <thead>
+      <div class="mt-10 overflow-hidden rounded-2xl border border-[--ui-border-color] shadow-sm shadow-gray-950/10">
+        <div class="border-b border-[--ui-border-color] bg-[--ui-soft-bg] px-6 py-4">
+          <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-caption">
+            Sold Items
+          </h3>
+        </div>
+        <div class="max-h-[320px] overflow-auto">
+          <table class="min-w-full divide-y divide-[--ui-border-color]">
+            <thead class="bg-[--ui-bg]">
               <tr>
-                <th>
+                <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.2em] text-caption">
                   Item
                 </th>
-                <th>
+                <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.2em] text-caption">
                   Sale Dates
                 </th>
-                <th>
+                <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.2em] text-caption">
                   Days Between Last Sales
                 </th>
-                <th>
+                <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.2em] text-caption">
                   Price
                 </th>
               </tr>
             </thead>
-            <tbody>
+            <tbody class="divide-y divide-[--ui-border-color]">
               <tr
                 v-for="item in filteredSoldItems"
                 :key="item.id"
-                class="hover"
+                class="transition hover:bg-primary-50/60"
               >
-                <td>
+                <td class="px-6 py-4 text-sm font-medium text-title">
                   {{ item.name }}
                 </td>
-                <td>
-                  <div v-if="item.saleDates && item.saleDates.length">
+                <td class="px-6 py-4 text-sm text-[--body-text-color]">
+                  <div v-if="item.saleDates && item.saleDates.length" class="space-y-1">
                     <div
                       v-for="(d, i) in item.saleDates"
                       :key="i"
@@ -101,74 +134,90 @@
                       {{ formatDate(d) }}
                     </div>
                   </div>
-                  <span v-else>-</span>
+                  <span v-else class="text-caption">-</span>
                 </td>
-                <td>
+                <td class="px-6 py-4 text-sm text-[--body-text-color]">
                   {{ daysBetweenLastSales(item.saleDates) }}
                 </td>
-                <td>
+                <td class="px-6 py-4 text-sm text-[--body-text-color]">
                   {{ item.price || '-' }}
                 </td>
               </tr>
               <tr v-if="!filteredSoldItems.length">
-                <td colspan="4" class="text-center">
-                  No sold items
+                <td colspan="4" class="px-6 py-12 text-center text-sm text-caption">
+                  No sold items match the selected filters.
                 </td>
               </tr>
             </tbody>
           </table>
         </div>
+      </div>
 
-        <h3 class="mt-8 mb-2 text-lg font-semibold">
-          Sales by Store
-        </h3>
-        <ul class="mb-6 list-disc ps-5">
-          <li
-            v-for="s in storeSales"
-            :key="s.store"
-          >
-            {{ s.store }} - {{ s.count }} sold (${{ s.revenue.toFixed(2) }})
-          </li>
-          <li
-            v-if="!storeSales.length"
-            class="list-none text-gray-500"
-          >
-            No data
-          </li>
-        </ul>
+      <div class="mt-10 grid gap-6 lg:grid-cols-2">
+        <div class="rounded-2xl border border-[--ui-border-color] bg-[--ui-bg] p-6 shadow-sm shadow-gray-950/10">
+          <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-caption">
+            Sales by Store
+          </h3>
+          <ul class="mt-4 space-y-3 text-sm text-[--body-text-color]">
+            <li
+              v-for="s in storeSales"
+              :key="s.store"
+              class="flex items-center justify-between rounded-card bg-[--ui-soft-bg] px-4 py-3 text-sm"
+            >
+              <span class="font-medium text-title">{{ s.store }}</span>
+              <span class="text-caption">{{ s.count }} sold · ${{ s.revenue.toFixed(2) }}</span>
+            </li>
+            <li
+              v-if="!storeSales.length"
+              class="rounded-card bg-[--ui-soft-bg] px-4 py-3 text-sm text-caption"
+            >
+              No store data available.
+            </li>
+          </ul>
+        </div>
+        <div class="rounded-2xl border border-[--ui-border-color] bg-[--ui-bg] p-6 shadow-sm shadow-gray-950/10">
+          <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-caption">
+            Top Sold Items
+          </h3>
+          <ul class="mt-4 space-y-3 text-sm text-[--body-text-color]">
+            <li
+              v-for="ti in topSoldItems"
+              :key="ti.name"
+              class="flex items-center justify-between rounded-card bg-[--ui-soft-bg] px-4 py-3 text-sm"
+            >
+              <span class="font-medium text-title">{{ ti.name }}</span>
+              <span class="text-caption">{{ ti.count }} sold</span>
+            </li>
+            <li
+              v-if="!topSoldItems.length"
+              class="rounded-card bg-[--ui-soft-bg] px-4 py-3 text-sm text-caption"
+            >
+              No top sellers yet.
+            </li>
+          </ul>
+        </div>
+      </div>
 
-        <h3 class="mb-2 text-lg font-semibold">
-          Top Sold Items
-        </h3>
-        <ul class="mb-6 list-disc ps-5">
-          <li
-            v-for="ti in topSoldItems"
-            :key="ti.name"
-          >
-            {{ ti.name }} - {{ ti.count }}
-          </li>
-          <li
-            v-if="!topSoldItems.length"
-            class="list-none text-gray-500"
-          >
-            No data
-          </li>
-        </ul>
-
-        <h3 class="mb-2 text-lg font-semibold">
-          Sales Chart
-        </h3>
-        <div class="w-full h-64">
+      <div class="mt-10 rounded-2xl border border-dashed border-[--ui-border-color] bg-[--ui-soft-bg] p-6">
+        <div class="flex items-center justify-between">
+          <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-caption">
+            Sales Chart
+          </h3>
+          <p class="text-xs text-caption">
+            Visualize month-over-month sales momentum.
+          </p>
+        </div>
+        <div class="mt-6 h-64 rounded-card bg-[--ui-bg] p-4 shadow-inner shadow-gray-950/10">
           <canvas
             v-if="hasChartData"
             ref="chartCanvas"
-            class="w-full h-full"
+            class="h-full w-full"
           />
           <p
             v-else
-            class="flex items-center justify-center h-full text-center text-gray-500"
+            class="flex h-full items-center justify-center text-center text-sm text-caption"
           >
-            No sales data
+            No sales data available for the selected filters.
           </p>
         </div>
       </div>

--- a/src/components/StatsDisplay.vue
+++ b/src/components/StatsDisplay.vue
@@ -1,67 +1,108 @@
 <template>
-  <div class="grid grid-cols-2 sm:grid-cols-5 gap-4 mb-6">
-    <div class="bg-white rounded-xl shadow-md p-4 text-center">
-      <h2 class="text-sm text-gray-500 uppercase">
-        Items
-      </h2>
-      <p class="text-2xl font-semibold text-gray-800">
+  <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+    <div class="rounded-card border border-[--ui-border-color] bg-[--ui-bg]/95 p-6 shadow-sm shadow-gray-950/10 backdrop-blur">
+      <p class="text-xs font-semibold uppercase tracking-[0.3em] text-caption">
+        Inventory
+      </p>
+      <p class="mt-4 text-3xl font-semibold text-title">
         {{ props.stats.items }}
       </p>
+      <p class="mt-2 text-sm text-caption">
+        Active items in stock
+      </p>
     </div>
-    <div
-      class="bg-white rounded-xl shadow-md p-4 text-center cursor-pointer"
+    <button
+      type="button"
+      class="group rounded-card border border-[--ui-border-color] bg-[--ui-bg] p-6 text-left shadow-sm shadow-gray-950/10 transition hover:border-primary-300 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
       @click="emit('show-sold-details')"
     >
-      <h2 class="text-sm text-gray-500 uppercase">
+      <p class="text-xs font-semibold uppercase tracking-[0.3em] text-caption">
         Sold
-      </h2>
-      <p class="text-2xl font-semibold text-gray-800">
-        {{ props.stats.sold }}
       </p>
-      <div class="w-full bg-gray-200 rounded-full h-2 mt-2">
+      <p class="mt-4 flex items-baseline gap-2 text-3xl font-semibold text-title">
+        {{ props.stats.sold }}
+        <span class="text-sm font-medium text-caption">items</span>
+      </p>
+      <div class="mt-5 h-2 w-full rounded-full bg-primary-100">
         <div
-          class="bg-blue-500 h-2 rounded-full"
+          class="h-2 rounded-full bg-primary-500 transition-all duration-500"
           :style="{ width: soldPercent + '%' }"
         />
       </div>
-    </div>
-    <div class="bg-white rounded-xl shadow-md p-4 text-center">
-      <h2 class="text-sm text-gray-500 uppercase">
-        Paid
-      </h2>
-      <p class="text-2xl font-semibold text-gray-800">
-        {{ props.stats.sold_paid }}
+      <p class="mt-2 text-xs text-caption">
+        {{ soldPercentLabel }}% of inventory sold
       </p>
-      <div class="w-full bg-gray-200 rounded-full h-2 mt-2">
+      <span class="mt-4 inline-flex items-center gap-2 text-sm font-medium text-primary-600">
+        View sold insights
+        <svg
+          class="size-4 transition-transform duration-300 group-hover:translate-x-1"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+        >
+          <path d="M5 12h14M13 6l6 6-6 6" />
+        </svg>
+      </span>
+    </button>
+    <div class="rounded-card border border-[--ui-border-color] bg-[--ui-bg] p-6 shadow-sm shadow-gray-950/10">
+      <p class="text-xs font-semibold uppercase tracking-[0.3em] text-caption">
+        Paid
+      </p>
+      <p class="mt-4 flex items-baseline gap-2 text-3xl font-semibold text-title">
+        {{ props.stats.sold_paid }}
+        <span class="text-sm font-medium text-caption">items</span>
+      </p>
+      <div class="mt-5 h-2 w-full rounded-full bg-success-100">
         <div
-          class="bg-green-500 h-2 rounded-full"
+          class="h-2 rounded-full bg-success-500 transition-all duration-500"
           :style="{ width: paidPercent + '%' }"
         />
       </div>
+      <p class="mt-2 text-xs text-caption">
+        {{ paidPercentLabel }}% of sold items paid
+      </p>
     </div>
-    <div
-      class="bg-gradient-to-r from-purple-600 to-pink-500 rounded-xl text-white shadow-md p-4 text-center cursor-pointer"
+    <button
+      type="button"
+      class="relative overflow-hidden rounded-card bg-gradient-to-br from-secondary-600 via-primary-600 to-primary-500 p-6 text-left text-white shadow-lg shadow-primary-950/20 transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70"
       @click="toggleOutstanding"
     >
-      <h2 class="text-sm uppercase">
-        {{ showOutstanding ? 'Outstanding' : 'Paid Total' }}
-      </h2>
-      <p class="text-2xl font-bold">
-        $
-        {{
-          (showOutstanding
-            ? props.stats.sold_unpaid_total
-            : props.stats.sold_paid_total
-          ).toFixed(2)
-        }}
-      </p>
-      <div class="w-full bg-white/30 rounded-full h-2 mt-2">
-        <div
-          class="bg-white h-2 rounded-full"
-          :style="{ width: revenuePercent + '%' }"
-        />
+      <span class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,theme(colors.white/0.35),transparent_55%)] opacity-70" />
+      <div class="relative">
+        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-white/70">
+          {{ displayTitle }}
+        </p>
+        <p class="mt-4 text-3xl font-semibold">
+          ${{ displayValue.toFixed(2) }}
+        </p>
+        <div class="mt-5 h-2 w-full rounded-full bg-white/30">
+          <div
+            class="h-2 rounded-full bg-white/90 transition-all duration-500"
+            :style="{ width: revenuePercent + '%' }"
+          />
+        </div>
+        <p class="mt-2 text-xs text-white/80">
+          {{ revenuePercentLabel }}% collected
+        </p>
+        <span class="mt-4 inline-flex items-center gap-2 text-sm font-medium">
+          {{ toggleHint }}
+          <svg
+            class="size-4 transition-transform duration-300"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+          >
+            <path d="M5 12h14M13 6l6 6-6 6" />
+          </svg>
+        </span>
       </div>
-    </div>
+    </button>
   </div>
 </template>
 
@@ -74,25 +115,40 @@ const props = defineProps<{
 }>();
 const emit = defineEmits(['show-sold-details']);
 
+const clampPercent = (value: number) => {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(100, value));
+};
+
 const showOutstanding = ref(false);
 const toggleOutstanding = () => {
   showOutstanding.value = !showOutstanding.value;
 };
 
 const soldPercent = computed(() =>
-  props.stats.items ? (props.stats.sold / props.stats.items) * 100 : 0
+  clampPercent(props.stats.items ? (props.stats.sold / props.stats.items) * 100 : 0)
 );
 
 const paidPercent = computed(() =>
-  props.stats.sold ? (props.stats.sold_paid / props.stats.sold) * 100 : 0
+  clampPercent(props.stats.sold ? (props.stats.sold_paid / props.stats.sold) * 100 : 0)
 );
 
 const revenuePercent = computed(() => {
   const total = props.stats.sold_paid_total + props.stats.sold_unpaid_total;
-  return total ? (props.stats.sold_paid_total / total) * 100 : 0;
+  return clampPercent(total ? (props.stats.sold_paid_total / total) * 100 : 0);
 });
-</script>
 
-<style scoped>
-/* Basic styling */
-</style>
+const soldPercentLabel = computed(() => Math.round(soldPercent.value));
+const paidPercentLabel = computed(() => Math.round(paidPercent.value));
+const revenuePercentLabel = computed(() => Math.round(revenuePercent.value));
+
+const displayValue = computed(() =>
+  showOutstanding.value ? props.stats.sold_unpaid_total : props.stats.sold_paid_total
+);
+const displayTitle = computed(() =>
+  showOutstanding.value ? 'Outstanding Balance' : 'Paid Total'
+);
+const toggleHint = computed(() =>
+  showOutstanding.value ? 'View paid totals' : 'View outstanding balance'
+);
+</script>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,18 +2,21 @@
 import preline from 'preline/plugin'
 import daisyui from 'daisyui'
 import plugin from 'tailwindcss/plugin'
+import { shade, components as tailusComponents, rounded, animations, palettes, palette } from '@tailus/themer'
 
 export default {
   content: [
     './index.html',
     './src/**/*.{vue,js,ts,jsx,tsx}',
-    './src/assets/**/*.css'
+    './src/assets/**/*.css',
+    './node_modules/@tailus/themer/dist/**/*.{js,ts}'
   ],
   theme: {
     fontFamily: {
       sans: ['Inter', 'sans-serif']
     },
     extend: {
+      colors: palettes.trust,
       spacing: {
         10.5: '2.625rem',
         160: '40rem'
@@ -26,6 +29,11 @@ export default {
   plugins: [
     preline,
     daisyui,
+    shade,
+    rounded,
+    tailusComponents,
+    animations,
+    palette,
     plugin(function({ addUtilities }) {
       addUtilities({
         '.outline-hidden': { outline: '0' }


### PR DESCRIPTION
## Summary
- add Tailus Themer and configure Tailwind to load its palettes, plugins, and Inter typography
- restyle the dashboard shell and stats widgets with Tailus surface, button, and gradient treatments
- rebuild the sold-details modal with filter controls, analytics lists, and a chart-ready canvas using Tailus patterns

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc30aa2b6c832085657d77469946a7