### PR TITLE
Fix invalid canvas closing tag in SoldDetailsModal

### DIFF
--- a/src/components/SoldDetailsModal.vue
+++ b/src/components/SoldDetailsModal.vue
@@ -212,7 +212,7 @@
             v-if="hasChartData"
             ref="chartCanvas"
             class="h-full w-full"
-          />
+          ></canvas>
           <p
             v-else
             class="flex h-full items-center justify-center text-center text-sm text-caption"


### PR DESCRIPTION
## Summary
- replace the self-closing `<canvas>` element in `SoldDetailsModal.vue` with a standard opening and closing tag to comply with Vue's template parser

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd6bf017d08320b18cac55a026180b