### PR TITLE
Polish dashboard layering and modal styling

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -246,7 +246,7 @@
     
       <div
         v-if="showForm && !editingItem"
-        class="fixed inset-0 z-[420] flex items-center justify-center overflow-y-auto bg-[--overlay-bg] px-4 py-8 backdrop-blur-sm"
+        class="fixed inset-0 z-[720] flex items-center justify-center overflow-y-auto bg-[--overlay-bg] px-4 py-8 backdrop-blur-sm"
         @click.self="showForm = false"
       >
         <ItemForm
@@ -257,7 +257,7 @@
 
       <div
         v-if="editingItem"
-        class="fixed inset-0 z-[420] flex items-center justify-center overflow-y-auto bg-[--overlay-bg] px-4 py-8 backdrop-blur-sm"
+        class="fixed inset-0 z-[720] flex items-center justify-center overflow-y-auto bg-[--overlay-bg] px-4 py-8 backdrop-blur-sm"
         @click.self="editingItem = null"
       >
         <EditItemForm

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,20 @@
 <template>
-  <div class="min-h-screen bg-[--ui-soft-bg] font-sans">
-    <div class="relative mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-8 px-4 py-10 sm:px-8 lg:px-12">
-      <div class="rounded-3xl border border-[--ui-border-color] bg-[--ui-bg]/80 p-6 shadow-sm shadow-gray-950/10 backdrop-blur">
-        <div class="flex flex-wrap items-center justify-between gap-6">
+  <div class="min-h-screen bg-gradient-to-br from-[#eef2ff] via-white to-[#fdf4ff] pb-16 font-sans">
+    <div class="relative mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-10 px-4 py-14 sm:px-8 lg:px-14">
+      <span
+        class="pointer-events-none absolute -left-40 top-24 hidden h-[26rem] w-[26rem] rounded-full bg-primary-200/30 blur-[160px] lg:block"
+        aria-hidden="true"
+      />
+      <span
+        class="pointer-events-none absolute -right-40 bottom-28 hidden h-[22rem] w-[22rem] rounded-full bg-secondary-200/35 blur-[160px] xl:block"
+        aria-hidden="true"
+      />
+      <div class="relative overflow-visible rounded-[38px] bg-gradient-to-br from-white/92 via-white/85 to-white/92 p-9 shadow-[0_48px_120px_-60px_rgba(90,104,255,0.55)] backdrop-blur-2xl ring-1 ring-white/60">
+        <span class="pointer-events-none absolute -right-28 -top-36 h-[20rem] w-[20rem] rounded-full bg-primary-200/40 blur-[150px]" />
+        <span class="pointer-events-none absolute -left-28 bottom-2 h-72 w-72 rounded-full bg-secondary-200/45 blur-[130px]" />
+        <div class="relative z-[460] flex flex-wrap items-center justify-between gap-6">
           <div class="flex flex-1 items-center gap-4">
-            <div class="flex size-14 items-center justify-center rounded-2xl bg-[--ui-soft-bg] shadow-inner shadow-gray-950/10">
+            <div class="flex size-16 items-center justify-center rounded-[30px] bg-white/80 shadow-[0_18px_40px_-28px_rgba(71,80,255,0.9)] backdrop-blur">
               <img
                 src="https://ielukqallxtceqmobmvp.supabase.co/storage/v1/object/public/images//uglysmall.png"
                 alt="ConsignTracker logo"
@@ -13,21 +23,21 @@
               >
             </div>
             <div>
-              <h1 class="text-3xl font-semibold text-title">
+              <h1 class="text-3xl font-semibold text-title text-primary-900">
                 ConsignTracker
               </h1>
-              <p class="text-sm text-caption">
+              <p class="text-sm text-caption text-primary-600">
                 by UglyStuff.ca
               </p>
             </div>
           </div>
           <div
             ref="menuRef"
-            class="relative"
+            class="relative z-[560]"
           >
             <button
               type="button"
-              class="inline-flex items-center gap-2 rounded-btn border border-[--ui-border-color] bg-[--ui-soft-bg] px-4 py-2 text-sm font-semibold text-title shadow-sm shadow-gray-950/5 transition hover:border-primary-300 hover:text-primary-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+              class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-[#4f46e5] via-[#7c3aed] to-[#ec4899] px-6 py-2.5 text-sm font-semibold text-white shadow-[0_26px_60px_-32px_rgba(68,64,200,0.9)] transition hover:-translate-y-0.5 hover:shadow-[0_32px_75px_-34px_rgba(68,64,200,0.9)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80"
               @click="toggleMenu"
             >
               <svg
@@ -45,13 +55,13 @@
             </button>
             <div
               v-if="showMenu"
-              class="absolute right-0 z-50 mt-3 w-64 rounded-2xl border border-[--ui-border-color] bg-[--ui-bg] p-3 shadow-xl shadow-gray-950/20"
+              class="absolute right-0 top-full z-[620] mt-4 w-72 overflow-hidden rounded-[30px] bg-gradient-to-br from-white/98 via-primary-50/85 to-white/98 p-4 shadow-[0_36px_90px_-40px_rgba(70,74,255,0.55)] ring-1 ring-white/70 backdrop-blur-2xl"
             >
-              <div class="px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-caption">
+              <div class="px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-primary-600">
                 Tools
               </div>
               <button
-                class="flex w-full items-center justify-between rounded-card px-3 py-2 text-sm font-medium text-[--body-text-color] transition hover:bg-[--ui-soft-bg]"
+                class="flex w-full items-center justify-between rounded-2xl px-4 py-2.5 text-sm font-medium text-[--body-text-color] transition hover:bg-primary-50/80"
                 @click="openExport"
               >
                 <span>Export Data</span>
@@ -68,7 +78,7 @@
                 </svg>
               </button>
               <button
-                class="mt-1 flex w-full items-center justify-between rounded-card px-3 py-2 text-sm font-medium text-[--body-text-color] transition hover:bg-[--ui-soft-bg]"
+                class="mt-1 flex w-full items-center justify-between rounded-2xl px-4 py-2.5 text-sm font-medium text-[--body-text-color] transition hover:bg-primary-50/80"
                 @click="goTo('/notes')"
               >
                 <span>Notes</span>
@@ -84,12 +94,12 @@
                   <path d="M5 12h14M13 6l6 6-6 6" />
                 </svg>
               </button>
-              <div class="my-2 h-px bg-[--ui-border-color]" />
-              <div class="px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-caption">
+              <div class="my-3 h-px bg-white/60" />
+              <div class="px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-primary-600">
                 Settings
               </div>
               <button
-                class="flex w-full items-center justify-between rounded-card px-3 py-2 text-sm font-medium text-[--body-text-color] transition hover:bg-[--ui-soft-bg]"
+                class="flex w-full items-center justify-between rounded-2xl px-4 py-2.5 text-sm font-medium text-[--body-text-color] transition hover:bg-primary-50/80"
                 @click="goTo('/settings')"
               >
                 <span>Settings</span>
@@ -105,12 +115,12 @@
                   <path d="M5 12h14M13 6l6 6-6 6" />
                 </svg>
               </button>
-              <div class="my-2 h-px bg-[--ui-border-color]" />
-              <div class="px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-caption">
+              <div class="my-3 h-px bg-white/60" />
+              <div class="px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-primary-600">
                 Contact
               </div>
               <button
-                class="flex w-full items-center justify-between rounded-card px-3 py-2 text-sm font-medium text-[--body-text-color] transition hover:bg-[--ui-soft-bg]"
+                class="flex w-full items-center justify-between rounded-2xl px-4 py-2.5 text-sm font-medium text-[--body-text-color] transition hover:bg-primary-50/80"
                 @click="reportIssue"
               >
                 <span>Report an Issue</span>
@@ -127,7 +137,7 @@
                 </svg>
               </button>
               <button
-                class="mt-1 flex w-full items-center justify-between rounded-card px-3 py-2 text-sm font-medium text-[--body-text-color] transition hover:bg-[--ui-soft-bg]"
+                class="mt-1 flex w-full items-center justify-between rounded-2xl px-4 py-2.5 text-sm font-medium text-[--body-text-color] transition hover:bg-primary-50/80"
                 @click="requestFeature"
               >
                 <span>Request a Feature</span>
@@ -143,12 +153,12 @@
                   <path d="M5 12h14M13 6l6 6-6 6" />
                 </svg>
               </button>
-              <div class="my-2 h-px bg-[--ui-border-color]" />
-              <div class="px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-caption">
+              <div class="my-3 h-px bg-white/60" />
+              <div class="px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-danger-500">
                 Sign Out
               </div>
               <button
-                class="flex w-full items-center justify-between rounded-card px-3 py-2 text-sm font-medium text-danger-600 transition hover:bg-danger-50"
+                class="flex w-full items-center justify-between rounded-2xl px-4 py-2.5 text-sm font-medium text-danger-600 transition hover:bg-danger-100/80"
                 @click="handleSignOut"
               >
                 <span>Sign Out</span>
@@ -169,19 +179,21 @@
         </div>
       </div>
 
-      <section class="rounded-3xl border border-[--ui-border-color] bg-[--ui-bg]/80 p-6 shadow-sm shadow-gray-950/10 backdrop-blur">
-        <div class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+      <section class="relative overflow-hidden rounded-[34px] bg-gradient-to-br from-white/92 via-primary-50/55 to-white/90 p-9 shadow-[0_42px_120px_-64px_rgba(88,100,255,0.6)] ring-1 ring-white/60 backdrop-blur-2xl">
+        <span class="pointer-events-none absolute -left-28 top-0 h-64 w-64 rounded-full bg-primary-200/45 blur-[150px]" />
+        <span class="pointer-events-none absolute -right-20 bottom-6 h-60 w-60 rounded-full bg-secondary-200/40 blur-[140px]" />
+        <div class="relative flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <h2 class="text-2xl font-semibold text-title">
+            <h2 class="text-2xl font-semibold text-title text-primary-900">
               Dashboard Snapshot
             </h2>
-            <p class="text-sm text-caption">
+            <p class="text-sm text-caption text-primary-600">
               Monitor sales, payments, and outstanding totals at a glance.
             </p>
           </div>
           <button
             type="button"
-            class="inline-flex items-center gap-2 text-sm font-medium text-primary-600 transition hover:text-primary-500"
+            class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-[#4f46e5] via-[#7c3aed] to-[#ec4899] px-6 py-2.5 text-sm font-semibold text-white shadow-[0_26px_60px_-32px_rgba(68,64,200,0.85)] transition hover:-translate-y-0.5 hover:shadow-[0_34px_80px_-36px_rgba(68,64,200,0.9)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80"
             @click="showSoldDetails = true"
           >
             View sold breakdown
@@ -198,7 +210,7 @@
             </svg>
           </button>
         </div>
-        <div class="mt-6">
+        <div class="relative mt-6">
           <StatsDisplay
             :stats="currentStats"
             @show-sold-details="showSoldDetails = true"
@@ -214,7 +226,7 @@
 
       <div
         v-if="lowStockItems.length"
-        class="mb-4 flex items-center gap-3 rounded-card border border-warning-200 bg-warning-50 px-4 py-3 text-sm text-warning-700 shadow-sm shadow-warning-500/10"
+        class="mb-4 flex items-center gap-3 rounded-card bg-warning-100/80 px-4 py-3 text-sm text-warning-800 shadow-[0_12px_30px_-18px_rgba(217,119,6,0.5)]"
       >
         ⚠️ {{ lowStockItems.length }} item(s) need restocking
       </div>
@@ -223,14 +235,14 @@
       <!-- Show server error if any -->
       <div
         v-if="serverError"
-        class="mb-4 flex items-center gap-3 rounded-card border border-danger-200 bg-danger-50 px-4 py-3 text-sm text-danger-700 shadow-sm shadow-danger-500/10"
+        class="mb-4 flex items-center gap-3 rounded-card bg-danger-100/80 px-4 py-3 text-sm text-danger-800 shadow-[0_12px_30px_-18px_rgba(220,38,38,0.45)]"
       >
         {{ serverError }}
       </div>
     
       <div
         v-if="showForm && !editingItem"
-        class="fixed inset-0 z-40 flex items-center justify-center bg-[--overlay-bg] backdrop-blur-sm"
+        class="fixed inset-0 z-[420] flex items-center justify-center overflow-y-auto bg-[--overlay-bg] px-4 py-8 backdrop-blur-sm"
         @click.self="showForm = false"
       >
         <ItemForm
@@ -241,7 +253,7 @@
 
       <div
         v-if="editingItem"
-        class="fixed inset-0 z-40 flex items-center justify-center bg-[--overlay-bg] backdrop-blur-sm"
+        class="fixed inset-0 z-[420] flex items-center justify-center overflow-y-auto bg-[--overlay-bg] px-4 py-8 backdrop-blur-sm"
         @click.self="editingItem = null"
       >
         <EditItemForm
@@ -257,11 +269,11 @@
       >
         <button
           type="button"
-          class="inline-flex items-center gap-2 rounded-btn bg-gradient-to-r from-primary-600 via-primary-500 to-secondary-500 px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-primary-950/20 transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70"
+          class="inline-flex items-center gap-3 rounded-full bg-gradient-to-r from-[#4f46e5] via-[#7c3aed] to-[#ec4899] px-8 py-3.5 text-base font-semibold text-white shadow-[0_30px_80px_-38px_rgba(68,64,200,0.85)] drop-shadow-[0_14px_32px_rgba(76,81,255,0.45)] transition hover:-translate-y-0.5 hover:shadow-[0_38px_110px_-42px_rgba(68,64,200,0.95)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80"
           @click="showForm = true"
         >
           <svg
-            class="size-4"
+            class="size-5"
             fill="none"
             stroke="currentColor"
             stroke-linecap="round"
@@ -275,16 +287,16 @@
         </button>
       </div>
     
-      <div class="flex flex-col flex-wrap items-center gap-3 rounded-3xl border border-[--ui-border-color] bg-[--ui-bg] p-4 shadow-sm shadow-gray-950/10 sm:flex-row sm:justify-between">
+      <div class="flex flex-col flex-wrap items-center gap-3 rounded-[30px] bg-gradient-to-r from-white/88 via-primary-50/60 to-white/88 p-4 shadow-[0_32px_95px_-58px_rgba(88,100,255,0.6)] ring-1 ring-white/60 backdrop-blur-2xl sm:flex-row sm:justify-between">
         <div class="flex flex-wrap items-center gap-3">
           <label
             for="view"
-            class="text-sm font-medium text-caption"
+            class="text-sm font-medium text-primary-600"
           >View</label>
           <select
             id="view"
             v-model="layout"
-            class="rounded-btn border border-[--ui-border-color] bg-[--ui-soft-bg] px-3 py-2 text-sm text-[--body-text-color] shadow-sm shadow-gray-950/5 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+            class="rounded-btn bg-white/80 px-3 py-2 text-sm text-[--body-text-color] shadow-[inset_0_0_0_1px_rgba(120,133,255,0.16)] focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-400"
           >
             <option value="grid">
               Grid
@@ -296,12 +308,12 @@
           <template v-if="layout === 'grid'">
             <label
               for="columns"
-              class="text-sm font-medium text-caption"
+              class="text-sm font-medium text-primary-600"
             >Columns</label>
             <select
               id="columns"
               v-model.number="columns"
-              class="rounded-btn border border-[--ui-border-color] bg-[--ui-soft-bg] px-3 py-2 text-sm text-[--body-text-color] shadow-sm shadow-gray-950/5 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+              class="rounded-btn bg-white/80 px-3 py-2 text-sm text-[--body-text-color] shadow-[inset_0_0_0_1px_rgba(120,133,255,0.16)] focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-400"
             >
               <option :value="1">
                 1 column
@@ -318,16 +330,16 @@
       </div>
 
 
-      <div class="flex flex-col gap-3 rounded-3xl border border-[--ui-border-color] bg-[--ui-bg] p-4 shadow-sm shadow-gray-950/10 sm:flex-row sm:items-center sm:justify-between">
+      <div class="flex flex-col gap-3 rounded-[30px] bg-gradient-to-r from-white/88 via-primary-50/60 to-white/88 p-4 shadow-[0_32px_95px_-58px_rgba(88,100,255,0.6)] ring-1 ring-white/60 backdrop-blur-2xl sm:flex-row sm:items-center sm:justify-between">
         <input
           v-model="searchQuery"
           type="text"
           placeholder="Search"
-          class="flex-1 rounded-btn border border-[--ui-border-color] bg-[--ui-soft-bg] px-4 py-2 text-sm text-[--body-text-color] shadow-sm shadow-gray-950/5 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          class="flex-1 rounded-btn bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-[inset_0_0_0_1px_rgba(120,133,255,0.18)] focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-400"
         >
         <button
           v-if="searchQuery"
-          class="inline-flex items-center gap-2 rounded-btn border border-[--ui-border-color] bg-[--ui-bg] px-3 py-2 text-sm font-medium text-caption transition hover:border-primary-300 hover:text-primary-600"
+          class="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-primary-100/90 via-primary-200/90 to-primary-100/90 px-4 py-2 text-sm font-medium text-primary-700 shadow-[0_18px_40px_-28px_rgba(86,96,255,0.7)] transition hover:-translate-y-0.5 hover:shadow-[0_26px_55px_-32px_rgba(86,96,255,0.75)]"
           @click="clearSearch"
         >
           Clear
@@ -336,7 +348,7 @@
 
       <div
         v-if="isLoading"
-        class="rounded-3xl border border-[--ui-border-color] bg-[--ui-bg] py-12 text-center text-sm text-caption shadow-inner shadow-gray-950/5"
+        class="rounded-[28px] bg-white/75 py-12 text-center text-sm text-primary-600 shadow-[inset_0_0_0_1px_rgba(120,133,255,0.12)]"
       >
         Loading items...
       </div>
@@ -422,6 +434,31 @@ const contactSubject = ref('');
 const menuRef = ref<HTMLElement | null>(null);
 const showSoldDetails = ref(false);
 
+const blockingOverlayActive = computed(
+  () =>
+    showForm.value ||
+    Boolean(editingItem.value) ||
+    showSoldDetails.value ||
+    showExportModal.value ||
+    showContact.value ||
+    Boolean(selectedImage.value)
+);
+
+function togglePageScrollLock(locked: boolean) {
+  if (typeof document === 'undefined') return;
+  const targets: HTMLElement[] = [document.body, document.documentElement];
+  targets.forEach(target => {
+    target.classList.toggle('overflow-hidden', locked);
+    if (locked) {
+      target.style.setProperty('overscroll-behavior', 'contain');
+      target.style.setProperty('touch-action', 'none');
+    } else {
+      target.style.removeProperty('overscroll-behavior');
+      target.style.removeProperty('touch-action');
+    }
+  });
+}
+
 function clearSearch() {
   searchQuery.value = '';
 }
@@ -460,7 +497,6 @@ function reportIssue() {
 
 function requestFeature() {
   openContact('Feature Request');
-
 }
 
 async function handleSignOut() {
@@ -481,7 +517,16 @@ onMounted(() => {
 
 onUnmounted(() => {
   document.removeEventListener('click', onClickOutside);
+  togglePageScrollLock(false);
 });
+
+watch(
+  blockingOverlayActive,
+  value => {
+    togglePageScrollLock(value);
+  },
+  { immediate: true }
+);
 
 const filteredItems = computed(() => {
   let results = items.value;

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -6,9 +6,19 @@
 @tailwind utilities;
 
 
+:root {
+  --ui-bg: rgba(255, 255, 255, 0.985);
+  --ui-soft-bg: #e7e7ff;
+  --ui-panel-bg: rgba(255, 255, 255, 0.92);
+  --body-text-color: #1d2147;
+  --overlay-bg: rgba(18, 21, 46, 0.72);
+}
+
+
 
 body {
-  @apply bg-[--ui-soft-bg];
+  background-image: linear-gradient(180deg, #eef2ff 0%, #ffffff 45%, #fef0ff 100%);
+  background-attachment: fixed;
   color: var(--body-text-color);
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;

--- a/src/components/ContactModal.vue
+++ b/src/components/ContactModal.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="fixed inset-0 z-[420] overflow-y-auto bg-[--overlay-bg] px-4 py-8 backdrop-blur-sm"
+    class="fixed inset-0 z-[720] overflow-y-auto bg-[--overlay-bg] px-4 py-8 backdrop-blur-sm"
     @click.self="emit('close')"
   >
     <form

--- a/src/components/ContactModal.vue
+++ b/src/components/ContactModal.vue
@@ -1,58 +1,66 @@
 <template>
   <div
-    class="fixed inset-0 flex items-center justify-center bg-black/30 backdrop-blur-sm z-50"
+    class="fixed inset-0 z-[420] overflow-y-auto bg-[--overlay-bg] px-4 py-8 backdrop-blur-sm"
     @click.self="emit('close')"
   >
     <form
-      class="bg-white rounded-lg p-4 w-96 shadow flex flex-col gap-3"
+      class="relative mx-auto flex w-full max-w-md flex-col gap-4 overflow-hidden overflow-y-auto rounded-3xl border border-primary-100 bg-gradient-to-br from-white/98 via-primary-50/85 to-white/98 px-6 py-6 shadow-2xl shadow-primary-900/20 backdrop-blur-2xl ring-1 ring-white/70 sm:px-8 max-h-[calc(100vh-4rem)]"
       @submit.prevent="handleSubmit"
     >
-      <div class="flex justify-between items-center mb-2">
-        <h2 class="text-lg font-bold">
-          Contact
+      <span class="pointer-events-none absolute -left-20 top-12 h-48 w-48 rounded-full bg-secondary-200/25 blur-[120px]" />
+      <button
+        type="button"
+        class="absolute right-5 top-5 inline-flex size-9 items-center justify-center rounded-full border border-white/60 bg-white/85 text-primary-600 shadow-sm shadow-primary-900/10 backdrop-blur transition hover:bg-primary-50/80 hover:text-primary-700"
+        @click="emit('close')"
+      >
+        <span class="sr-only">Close</span>
+        &times;
+      </button>
+      <div class="relative">
+        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-primary-600">
+          Get in Touch
+        </p>
+        <h2 class="mt-2 text-2xl font-semibold text-title text-primary-900">
+          Contact Support
         </h2>
-        <button
-          type="button"
-          class="text-gray-500"
-          @click="emit('close')"
-        >
-          &times;
-        </button>
+        <p class="mt-2 text-sm text-primary-600">
+          We typically reply within one business day. Let us know how we can help.
+        </p>
       </div>
-      <div>
-        <label class="block text-sm mb-1">Your Email</label>
+      <label class="relative flex flex-col gap-2 text-sm text-primary-600">
+        <span class="font-medium text-primary-800">Your Email</span>
         <input
           v-model="from"
           type="email"
-          class="w-full px-3 py-2 border rounded"
+          class="rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
           required
         >
-      </div>
-      <div>
-        <label class="block text-sm mb-1">Subject</label>
+      </label>
+      <label class="relative flex flex-col gap-2 text-sm text-primary-600">
+        <span class="font-medium text-primary-800">Subject</span>
         <input
           v-model="subject"
           type="text"
-          class="w-full px-3 py-2 border rounded"
+          class="rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
           required
         >
-      </div>
-      <div>
-        <label class="block text-sm mb-1">Message</label>
+      </label>
+      <label class="relative flex flex-col gap-2 text-sm text-primary-600">
+        <span class="font-medium text-primary-800">Message</span>
         <textarea
           v-model="message"
           rows="4"
-          class="w-full px-3 py-2 border rounded"
+          class="min-h-32 rounded-2xl border border-primary-100 bg-white/90 px-4 py-3 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
           required
         />
-      </div>
+      </label>
       <button
-        class="flex items-center justify-center bg-gradient-to-r from-purple-600 to-pink-500 text-white font-semibold px-4 py-2 rounded-md shadow hover:opacity-90 active:scale-95 transition w-full disabled:opacity-50"
+        class="mt-2 flex items-center justify-center gap-2 rounded-full bg-gradient-to-r from-primary-600 via-indigo-500 to-secondary-500 px-5 py-3 text-sm font-semibold text-white shadow-xl shadow-primary-950/30 drop-shadow-[0_12px_32px_rgba(76,81,255,0.45)] transition hover:translate-y-0.5 hover:shadow-2xl disabled:opacity-60"
         :disabled="sending"
       >
         <svg
           v-if="sending"
-          class="animate-spin h-4 w-4 mr-2 text-white"
+          class="size-4 animate-spin text-white"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
@@ -71,7 +79,7 @@
             d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
           />
         </svg>
-        <span>{{ sending ? 'Sending...' : 'Send' }}</span>
+        <span>{{ sending ? 'Sending…' : 'Send Message' }}</span>
       </button>
     </form>
   </div>

--- a/src/components/EditItemForm.vue
+++ b/src/components/EditItemForm.vue
@@ -1,243 +1,264 @@
 <template>
-  <div class="relative z-50 bg-white p-6 rounded-xl shadow-xl max-w-md mx-auto mt-10 overflow-y-auto max-h-[90vh]">
-    <h2 class="text-xl font-semibold mb-4">
-      Edit Item
-    </h2>
-
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Item Name</label>
-      <input
-        v-model="form.name"
-        type="text"
-        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
-        placeholder="Enter item name"
-      >
+  <div class="relative w-full max-w-2xl rounded-3xl border border-primary-100 bg-gradient-to-br from-white/98 via-primary-50/85 to-white/98 px-6 py-8 shadow-2xl shadow-primary-900/20 backdrop-blur-2xl ring-1 ring-white/70 sm:px-10 max-h-[calc(100vh-4rem)] overflow-y-auto">
+    <div class="flex flex-col gap-2 border-b border-primary-100/70 pb-6">
+      <span class="text-xs font-semibold uppercase tracking-[0.3em] text-primary-600">Update Inventory</span>
+      <h2 class="text-2xl font-semibold text-title text-primary-900">
+        Edit Item
+      </h2>
+      <p class="text-sm text-primary-600">
+        Adjust stock levels, pricing, and sale history to keep your catalog accurate.
+      </p>
     </div>
 
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Location</label>
-      <input
-        v-model="form.location"
-        list="storeOptionsList"
-        type="text"
-        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
-        placeholder="Enter item location"
-      >
-      <datalist id="storeOptionsList">
-        <option
-          v-for="store in storeOptions"
-          :key="store"
-          :value="store"
-        />
-      </datalist>
-    </div>
+    <div class="mt-6 grid gap-4 sm:grid-cols-2">
+      <label class="flex flex-col gap-2 text-sm text-primary-600 sm:col-span-2">
+        <span class="font-medium text-primary-800">Item Name</span>
+        <input
+          v-model="form.name"
+          type="text"
+          class="rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          placeholder="Enter item name"
+        >
+      </label>
 
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Price</label>
-      <input
-        v-model="displayPrice"
-        type="text"
-        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
-        placeholder="Enter item price"
-      >
-    </div>
+      <label class="flex flex-col gap-2 text-sm text-primary-600">
+        <span class="font-medium text-primary-800">Location</span>
+        <input
+          v-model="form.location"
+          list="storeOptionsList"
+          type="text"
+          class="rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          placeholder="Enter item location"
+        >
+        <datalist id="storeOptionsList">
+          <option
+            v-for="store in storeOptions"
+            :key="store"
+            :value="store"
+          />
+        </datalist>
+      </label>
 
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Shop Fee %</label>
-      <input
-        v-model.number="form.feePercent"
-        type="number"
-        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
-        min="0"
-        step="0.1"
-      >
-    </div>
+      <label class="flex flex-col gap-2 text-sm text-primary-600">
+        <span class="font-medium text-primary-800">Price</span>
+        <input
+          v-model="displayPrice"
+          type="text"
+          class="rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          placeholder="Enter item price"
+        >
+      </label>
 
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Quantity</label>
-      <input
-        v-model.number="form.quantity"
-        type="number"
-        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
-        min="1"
-      >
-    </div>
+      <label class="flex flex-col gap-2 text-sm text-primary-600">
+        <span class="font-medium text-primary-800">Shop Fee %</span>
+        <input
+          v-model.number="form.feePercent"
+          type="number"
+          class="rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          min="0"
+          step="0.1"
+        >
+      </label>
 
-    <div class="mb-4">
-      <label
-        class="block text-sm font-medium text-gray-700 mb-1"
-        for="edit_min_quantity"
-      >Restock Alert Level</label>
-      <input
-        id="edit_min_quantity"
-        v-model.number="form.minQuantity"
-        type="number"
-        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
-        min="0"
-      >
-    </div>
+      <label class="flex flex-col gap-2 text-sm text-primary-600">
+        <span class="font-medium text-primary-800">Quantity</span>
+        <input
+          v-model.number="form.quantity"
+          type="number"
+          class="rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          min="1"
+        >
+      </label>
 
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Past Sales</label>
-      <input
-        v-model.number="form.pastSales"
-        type="number"
-        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
-        min="0"
-      >
-    </div>
+      <label class="flex flex-col gap-2 text-sm text-primary-600">
+        <span class="font-medium text-primary-800">Restock Alert Level</span>
+        <input
+          id="edit_min_quantity"
+          v-model.number="form.minQuantity"
+          type="number"
+          class="rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          min="0"
+        >
+      </label>
 
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Sale Dates</label>
-      <div
-        v-for="(d, idx) in form.saleDates"
-        :key="idx"
-        class="flex items-center mb-2"
-      >
-        <DatePicker v-model="form.saleDates[idx]" class="flex-1" />
+      <label class="flex flex-col gap-2 text-sm text-primary-600">
+        <span class="font-medium text-primary-800">Past Sales</span>
+        <input
+          v-model.number="form.pastSales"
+          type="number"
+          class="rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          min="0"
+        >
+      </label>
+
+      <div class="sm:col-span-2">
+        <span class="block text-sm font-medium text-primary-800">Sale Dates</span>
+        <div
+          v-for="(d, idx) in form.saleDates"
+          :key="idx"
+          class="mt-2 flex flex-col gap-3 rounded-card border border-primary-100 bg-white/90 p-3 shadow-inner shadow-primary-900/5 sm:flex-row sm:items-center"
+        >
+          <DatePicker
+            v-model="form.saleDates[idx]"
+            class="flex-1"
+          />
+          <button
+            type="button"
+            class="inline-flex items-center justify-center rounded-full bg-danger-50 px-4 py-2 text-sm font-semibold text-danger-600 transition hover:bg-danger-100"
+            @click="removeSaleDate(idx)"
+          >
+            Remove
+          </button>
+        </div>
         <button
           type="button"
-          class="ml-2 text-red-600"
-          @click="removeSaleDate(idx)"
+          class="mt-3 inline-flex items-center gap-2 rounded-full border border-primary-100 bg-white/90 px-4 py-2 text-sm font-semibold text-primary-700 shadow-sm shadow-primary-900/10 transition hover:bg-primary-50/80"
+          @click="addSaleDate"
         >
-          ✕
+          Add Sale Date
         </button>
       </div>
-      <button
-        type="button"
-        class="btn btn-sm btn-secondary"
-        @click="addSaleDate"
-      >
-        Add Sale Date
-      </button>
-    </div>
 
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700 mb-1">SKU Codes</label>
-      <input
-        v-model="skuInput"
-        list="skuOptionsList"
-        type="text"
-        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
-        placeholder="ABC123, ABC124"
-      >
-      <datalist id="skuOptionsList">
-        <option
-          v-for="sku in skuOptions"
-          :key="sku"
-          :value="sku"
+      <label class="flex flex-col gap-2 text-sm text-primary-600 sm:col-span-2">
+        <span class="font-medium text-primary-800">SKU Codes</span>
+        <input
+          v-model="skuInput"
+          list="skuOptionsList"
+          type="text"
+          class="rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          placeholder="ABC123, ABC124"
+        >
+        <datalist id="skuOptionsList">
+          <option
+            v-for="sku in skuOptions"
+            :key="sku"
+            :value="sku"
+          />
+        </datalist>
+      </label>
+
+      <label class="flex flex-col gap-2 text-sm text-primary-600">
+        <span class="font-medium text-primary-800">Date Added</span>
+        <DatePicker
+          v-model="form.dateAdded"
+          placeholder="Select day"
         />
-      </datalist>
-    </div>
+      </label>
 
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Date Added</label>
-      <DatePicker
-        v-model="form.dateAdded"
-        placeholder="Select day"
-      />
-    </div>
-
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Image</label>
-      <input
-        type="file"
-        accept="image/*"
-        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
-        @change="onFileChange"
-      >
-      <div
-        v-if="previewUrl"
-        class="mt-2"
-      >
-        <img
-          :src="previewUrl"
-          alt="Preview"
-          class="mt-2 rounded max-w-full max-h-40 object-contain"
-        >
-        <button
-          class="mt-2 bg-blue-500 hover:bg-blue-600 text-white px-2 py-1 rounded"
-          @click="editImage"
-        >
-          Edit Image
-        </button>
-      </div>
-    </div>
-
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Item Details</label>
-      <textarea
-        v-model="form.details"
-        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
-        rows="3"
-        placeholder="Enter item details"
-      />
-    </div>
-
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Status</label>
-      <select
-        v-model="form.status"
-        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
-      >
-        <option
-          v-for="option in statusOptions"
-          :key="option.value"
-          :value="option.value"
-        >
-          {{ option.label }}
-        </option>
-      </select>
-    </div>
-
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Tags</label>
-      <div class="flex flex-wrap mb-2">
-        <span
-          v-for="(tag, idx) in form.tags"
-          :key="idx"
-          class="bg-gray-200 rounded-full px-2 py-1 text-sm mr-2 mb-2 flex items-center"
-        >
-          {{ tag }}
-          <button
-            class="ml-1 text-red-500"
-            @click="removeTag(idx)"
+      <div class="sm:col-span-2">
+        <label class="flex flex-col gap-2 text-sm text-primary-600">
+          <span class="font-medium text-primary-800">Image</span>
+          <input
+            type="file"
+            accept="image/*"
+            class="rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+            @change="onFileChange"
           >
-            ✕
+        </label>
+        <div
+          v-if="previewUrl"
+          class="mt-3 rounded-card border border-primary-100 bg-white/90 p-3 shadow-inner shadow-primary-900/5"
+        >
+          <img
+            :src="previewUrl"
+            alt="Preview"
+            class="max-h-48 w-full rounded-card object-contain"
+          >
+          <button
+            class="mt-3 inline-flex items-center justify-center rounded-full bg-gradient-to-r from-primary-500 via-indigo-500 to-secondary-500 px-4 py-2 text-sm font-semibold text-white shadow-md shadow-primary-900/20 transition hover:from-primary-500 hover:via-indigo-500 hover:to-secondary-500"
+            @click="editImage"
+          >
+            Edit Image
           </button>
-        </span>
+        </div>
       </div>
-      <input
-        v-model="tagInput"
-        type="text"
-        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
-        placeholder="Add tag and press Enter"
-        @keyup.enter.prevent="addTag"
-      >
+
+      <label class="flex flex-col gap-2 text-sm text-primary-600 sm:col-span-2">
+        <span class="font-medium text-primary-800">Item Details</span>
+        <textarea
+          v-model="form.details"
+          class="min-h-24 rounded-2xl border border-primary-100 bg-white/90 px-4 py-3 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          rows="3"
+          placeholder="Enter item details"
+        />
+      </label>
+
+      <label class="flex flex-col gap-2 text-sm text-primary-600 sm:col-span-2">
+        <span class="font-medium text-primary-800">Status</span>
+        <select
+          v-model="form.status"
+          class="rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+        >
+          <option
+            v-for="option in statusOptions"
+            :key="option.value"
+            :value="option.value"
+          >
+            {{ option.label }}
+          </option>
+        </select>
+      </label>
+
+      <div class="sm:col-span-2">
+        <span class="block text-sm font-medium text-primary-800">Tags</span>
+        <div class="mt-2 flex flex-wrap gap-2">
+          <template v-if="form.tags.length">
+            <span
+              v-for="(tag, idx) in form.tags"
+              :key="idx"
+              class="inline-flex items-center gap-2 rounded-full bg-primary-50 px-3 py-1 text-xs font-semibold text-primary-700 shadow-sm shadow-primary-900/10"
+            >
+              {{ tag }}
+              <button
+                type="button"
+                class="text-primary-500 transition hover:text-danger-500"
+                @click="removeTag(idx)"
+              >
+                ✕
+              </button>
+            </span>
+          </template>
+          <span
+            v-else
+            class="rounded-full bg-white/90 px-3 py-1 text-xs text-primary-500"
+          >
+            No tags added yet.
+          </span>
+        </div>
+        <input
+          v-model="tagInput"
+          type="text"
+          class="mt-3 rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          placeholder="Add tag and press Enter"
+          @keyup.enter.prevent="addTag"
+        >
+      </div>
     </div>
 
-    <div class="flex gap-3 mt-4">
+    <div class="mt-8 flex flex-col gap-3 sm:flex-row">
       <button
-        class="bg-gradient-to-r from-purple-600 to-pink-500 text-white font-semibold px-4 py-2 rounded-md shadow hover:opacity-90 active:scale-95 transition w-full disabled:opacity-50"
+        class="inline-flex flex-1 items-center justify-center gap-2 rounded-full bg-gradient-to-r from-primary-600 via-indigo-500 to-secondary-500 px-6 py-3 text-sm font-semibold text-white shadow-xl shadow-primary-950/30 drop-shadow-[0_12px_32px_rgba(76,81,255,0.45)] transition hover:translate-y-0.5 hover:shadow-2xl disabled:opacity-60"
         :disabled="loading"
         @click="handleSubmit"
       >
         Update Item
       </button>
       <button
-        class="bg-gray-200 text-gray-800 font-semibold px-4 py-2 rounded-md hover:bg-gray-300 transition w-full"
+        class="inline-flex flex-1 items-center justify-center rounded-full border border-primary-100 bg-white/90 px-6 py-3 text-sm font-semibold text-primary-700 shadow-md shadow-primary-900/10 transition hover:bg-primary-50/80 disabled:opacity-60"
         :disabled="loading"
         @click="$emit('cancel')"
       >
         Cancel
       </button>
     </div>
+
     <div
       v-if="loading"
-      class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50"
+      class="absolute inset-0 z-10 flex items-center justify-center rounded-3xl bg-[--overlay-bg]"
     >
-      <div class="animate-spin rounded-full h-16 w-16 border-4 border-white border-t-transparent" />
+      <div class="h-12 w-12 animate-spin rounded-full border-4 border-white/80 border-t-transparent" />
     </div>
+
     <ImageCropper
       :src="cropperSrc"
       :visible="showCropper"
@@ -459,4 +480,3 @@ async function handleSubmit() {
 <style scoped>
 /* Add any component-specific styles here */
 </style>
-

--- a/src/components/ExportModal.vue
+++ b/src/components/ExportModal.vue
@@ -1,28 +1,36 @@
 <template>
   <div
-    class="fixed inset-0 flex items-center justify-center bg-black/30 backdrop-blur-sm z-50"
+    class="fixed inset-0 z-[420] overflow-y-auto bg-[--overlay-bg] px-4 py-8 backdrop-blur-sm"
     @click.self="emit('close')"
   >
-    <div class="bg-white rounded-lg p-4 w-80 shadow">
-      <div class="flex justify-between items-center mb-3">
-        <h2 class="text-lg font-bold">
-          Export Data
+    <div class="relative mx-auto w-full max-w-sm overflow-hidden overflow-y-auto rounded-3xl border border-primary-100 bg-gradient-to-br from-white/98 via-primary-50/85 to-white/98 px-6 py-6 shadow-2xl shadow-primary-900/20 backdrop-blur-2xl ring-1 ring-white/70 sm:px-8 max-h-[calc(100vh-4rem)]">
+      <span class="pointer-events-none absolute -right-14 -top-16 h-36 w-36 rounded-full bg-primary-200/30 blur-3xl" />
+      <button
+        class="absolute right-5 top-5 inline-flex size-9 items-center justify-center rounded-full border border-white/60 bg-white/85 text-primary-600 shadow-sm shadow-primary-900/10 backdrop-blur transition hover:bg-primary-50/80 hover:text-primary-700"
+        @click="emit('close')"
+      >
+        <span class="sr-only">Close</span>
+        &times;
+      </button>
+      <div class="relative">
+        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-primary-600">
+          Data Tools
+        </p>
+        <h2 class="mt-2 text-2xl font-semibold text-title text-primary-900">
+          Export Inventory
         </h2>
-        <button
-          class="text-gray-500"
-          @click="emit('close')"
-        >
-          &times;
-        </button>
+        <p class="mt-2 text-sm text-primary-600">
+          Choose a format to download your items for reporting or backups.
+        </p>
       </div>
       <label
         for="format"
-        class="block text-sm mb-1"
+        class="mt-6 block text-sm font-medium text-primary-700"
       >Format</label>
       <select
         id="format"
         v-model="format"
-        class="w-full mb-4 px-3 py-2 border rounded"
+        class="mt-2 w-full rounded-btn border border-primary-100 bg-white/90 px-3 py-2 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
       >
         <option value="pdf">
           PDF
@@ -38,13 +46,13 @@
         </option>
       </select>
       <button
-        class="flex items-center justify-center bg-gradient-to-r from-purple-600 to-pink-500 text-white font-semibold px-4 py-2 rounded-md shadow hover:opacity-90 active:scale-95 transition w-full disabled:opacity-50"
+        class="mt-6 flex w-full items-center justify-center gap-2 rounded-full bg-gradient-to-r from-primary-600 via-indigo-500 to-secondary-500 px-5 py-3 text-sm font-semibold text-white shadow-xl shadow-primary-950/30 drop-shadow-[0_12px_32px_rgba(76,81,255,0.45)] transition hover:translate-y-0.5 hover:shadow-2xl disabled:opacity-60"
         :disabled="exporting"
         @click="handleExport"
       >
         <svg
           v-if="exporting"
-          class="animate-spin h-4 w-4 mr-2 text-white"
+          class="size-4 animate-spin text-white"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
@@ -63,7 +71,7 @@
             d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
           />
         </svg>
-        <span>{{ exporting ? 'Exporting...' : `Export ${format.toUpperCase()}` }}</span>
+        <span>{{ exporting ? 'Exporting…' : `Export ${format.toUpperCase()}` }}</span>
       </button>
     </div>
   </div>

--- a/src/components/ExportModal.vue
+++ b/src/components/ExportModal.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="fixed inset-0 z-[420] overflow-y-auto bg-[--overlay-bg] px-4 py-8 backdrop-blur-sm"
+    class="fixed inset-0 z-[720] overflow-y-auto bg-[--overlay-bg] px-4 py-8 backdrop-blur-sm"
     @click.self="emit('close')"
   >
     <div class="relative mx-auto w-full max-w-sm overflow-hidden overflow-y-auto rounded-3xl border border-primary-100 bg-gradient-to-br from-white/98 via-primary-50/85 to-white/98 px-6 py-6 shadow-2xl shadow-primary-900/20 backdrop-blur-2xl ring-1 ring-white/70 sm:px-8 max-h-[calc(100vh-4rem)]">

--- a/src/components/ItemForm.vue
+++ b/src/components/ItemForm.vue
@@ -1,186 +1,194 @@
 <template>
-  <div class="relative z-50 bg-white p-6 rounded-xl shadow-xl max-w-md mx-auto mt-10 overflow-y-auto max-h-[90vh]">
-    <h2 class="text-xl font-semibold mb-4">
-      Add New Item
-    </h2>
-    
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Item Name</label>
-      <input
-        v-model="newItem.name"
-        type="text"
-        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
-        placeholder="Enter item name"
-      >
+  <div class="relative w-full max-w-2xl rounded-3xl border border-primary-100 bg-gradient-to-br from-white/98 via-primary-50/85 to-white/98 px-6 py-8 shadow-2xl shadow-primary-900/20 backdrop-blur-2xl ring-1 ring-white/70 sm:px-10 max-h-[calc(100vh-4rem)] overflow-y-auto">
+    <div class="flex flex-col gap-2 border-b border-primary-100/70 pb-6">
+      <span class="text-xs font-semibold uppercase tracking-[0.3em] text-primary-600">New Inventory</span>
+      <h2 class="text-2xl font-semibold text-title text-primary-900">
+        Add New Item
+      </h2>
+      <p class="text-sm text-primary-600">
+        Provide location, pricing, and inventory details so the item is ready to track right away.
+      </p>
     </div>
 
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Location</label>
-      <input
-        v-model="newItem.location"
-        list="storeOptionsList"
-        type="text"
-        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
-        placeholder="Enter item location"
-      >
-      <datalist id="storeOptionsList">
-        <option
-          v-for="store in storeOptions"
-          :key="store"
-          :value="store"
-        />
-      </datalist>
-    </div>
-
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Price</label>
-      <input
-        v-model="displayPrice"
-        type="text"
-        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
-        placeholder="Enter item price"
-      >
-    </div>
-
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Shop Fee %</label>
-      <input
-        v-model.number="newItem.feePercent"
-        type="number"
-        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
-        min="0"
-        step="0.1"
-      >
-    </div>
-
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Quantity</label>
-      <input
-        v-model.number="newItem.quantity"
-        type="number"
-        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
-        min="1"
-      >
-    </div>
-
-    <div class="mb-4">
-      <label
-        class="block text-sm font-medium text-gray-700 mb-1"
-        for="min_quantity"
-      >Restock Alert Level</label>
-      <input
-        id="min_quantity"
-        v-model.number="newItem.minQuantity"
-        type="number"
-        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
-        min="0"
-      >
-    </div>
-
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Past Sales</label>
-      <input
-        v-model.number="newItem.pastSales"
-        type="number"
-        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
-        min="0"
-      >
-    </div>
-
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700 mb-1">SKU Codes</label>
-      <input
-        v-model="skuInput"
-        list="skuOptionsList"
-        type="text"
-        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
-        placeholder="ABC123, ABC124"
-      >
-      <datalist id="skuOptionsList">
-        <option
-          v-for="sku in skuOptions"
-          :key="sku"
-          :value="sku"
-        />
-      </datalist>
-    </div>
-
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700 mb-1">
-        Image <span class="text-red-500">*</span>
+    <div class="mt-6 grid gap-4 sm:grid-cols-2">
+      <label class="flex flex-col gap-2 text-sm text-primary-600 sm:col-span-2">
+        <span class="font-medium text-primary-800">Item Name</span>
+        <input
+          v-model="newItem.name"
+          type="text"
+          class="rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          placeholder="Enter item name"
+        >
       </label>
-      <input
-        type="file"
-        accept="image/*"
-        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
-        required
-        @change="onFileChange"
-      >
-      <div
-        v-if="previewUrl"
-        class="mt-2"
-      >
-        <img
-          :src="previewUrl"
-          alt="Preview"
-          class="mt-2 rounded max-w-full max-h-40 object-contain"
+
+      <label class="flex flex-col gap-2 text-sm text-primary-600">
+        <span class="font-medium text-primary-800">Location</span>
+        <input
+          v-model="newItem.location"
+          list="storeOptionsList"
+          type="text"
+          class="rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          placeholder="Enter item location"
         >
-        <button
-          class="mt-2 bg-blue-500 hover:bg-blue-600 text-white px-2 py-1 rounded"
-          @click="editImage"
+        <datalist id="storeOptionsList">
+          <option
+            v-for="store in storeOptions"
+            :key="store"
+            :value="store"
+          />
+        </datalist>
+      </label>
+
+      <label class="flex flex-col gap-2 text-sm text-primary-600">
+        <span class="font-medium text-primary-800">Price</span>
+        <input
+          v-model="displayPrice"
+          type="text"
+          class="rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          placeholder="Enter item price"
         >
-          Edit Image
-        </button>
+      </label>
+
+      <label class="flex flex-col gap-2 text-sm text-primary-600">
+        <span class="font-medium text-primary-800">Shop Fee %</span>
+        <input
+          v-model.number="newItem.feePercent"
+          type="number"
+          class="rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          min="0"
+          step="0.1"
+        >
+      </label>
+
+      <label class="flex flex-col gap-2 text-sm text-primary-600">
+        <span class="font-medium text-primary-800">Quantity</span>
+        <input
+          v-model.number="newItem.quantity"
+          type="number"
+          class="rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          min="1"
+        >
+      </label>
+
+      <label class="flex flex-col gap-2 text-sm text-primary-600">
+        <span class="font-medium text-primary-800">Restock Alert Level</span>
+        <input
+          id="min_quantity"
+          v-model.number="newItem.minQuantity"
+          type="number"
+          class="rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          min="0"
+        >
+      </label>
+
+      <label class="flex flex-col gap-2 text-sm text-primary-600">
+        <span class="font-medium text-primary-800">Past Sales</span>
+        <input
+          v-model.number="newItem.pastSales"
+          type="number"
+          class="rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          min="0"
+        >
+      </label>
+
+      <label class="flex flex-col gap-2 text-sm text-primary-600 sm:col-span-2">
+        <span class="font-medium text-primary-800">SKU Codes</span>
+        <input
+          v-model="skuInput"
+          list="skuOptionsList"
+          type="text"
+          class="rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          placeholder="ABC123, ABC124"
+        >
+        <datalist id="skuOptionsList">
+          <option
+            v-for="sku in skuOptions"
+            :key="sku"
+            :value="sku"
+          />
+        </datalist>
+      </label>
+
+      <div class="sm:col-span-2">
+        <label class="flex flex-col gap-2 text-sm text-primary-600">
+          <span class="font-medium text-primary-800">
+            Image <span class="text-danger-500">*</span>
+          </span>
+          <input
+            type="file"
+            accept="image/*"
+            class="rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+            required
+            @change="onFileChange"
+          >
+        </label>
+        <div
+          v-if="previewUrl"
+          class="mt-3 rounded-card border border-primary-100 bg-white/90 p-3 shadow-inner shadow-primary-900/5"
+        >
+          <img
+            :src="previewUrl"
+            alt="Preview"
+            class="max-h-48 w-full rounded-card object-contain"
+          >
+          <button
+            class="mt-3 inline-flex items-center justify-center rounded-full bg-gradient-to-r from-primary-500 via-indigo-500 to-secondary-500 px-4 py-2 text-sm font-semibold text-white shadow-md shadow-primary-900/20 transition hover:from-primary-500 hover:via-indigo-500 hover:to-secondary-500"
+            @click="editImage"
+          >
+            Edit Image
+          </button>
+        </div>
       </div>
-    </div>
 
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Item Details</label>
-      <textarea
-        v-model="newItem.details"
-        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
-        rows="3"
-        placeholder="Enter item details"
-      />
-    </div>
+      <label class="flex flex-col gap-2 text-sm text-primary-600 sm:col-span-2">
+        <span class="font-medium text-primary-800">Item Details</span>
+        <textarea
+          v-model="newItem.details"
+          class="min-h-24 rounded-2xl border border-primary-100 bg-white/90 px-4 py-3 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+          rows="3"
+          placeholder="Enter item details"
+        />
+      </label>
 
-    <div class="mb-4">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Status</label>
-      <select
-        v-model="newItem.status"
-        class="w-full px-4 py-2 rounded-md border border-gray-300 shadow-sm focus:ring-2 focus:ring-purple-500 mb-4"
-      >
-        <option
-          v-for="option in statusOptions"
-          :key="option.value"
-          :value="option.value"
+      <label class="flex flex-col gap-2 text-sm text-primary-600 sm:col-span-2">
+        <span class="font-medium text-primary-800">Status</span>
+        <select
+          v-model="newItem.status"
+          class="rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-inner shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
         >
-          {{ option.label }}
-        </option>
-      </select>
+          <option
+            v-for="option in statusOptions"
+            :key="option.value"
+            :value="option.value"
+          >
+            {{ option.label }}
+          </option>
+        </select>
+      </label>
     </div>
 
-    <div class="flex gap-3 mt-4">
+    <div class="mt-8 flex flex-col gap-3 sm:flex-row">
       <button
-        class="w-full bg-gradient-to-r from-purple-600 to-pink-500 text-white font-semibold px-4 py-2 rounded-md shadow hover:opacity-90 active:scale-95 transition disabled:opacity-50"
+        class="inline-flex flex-1 items-center justify-center gap-2 rounded-full bg-gradient-to-r from-primary-600 via-indigo-500 to-secondary-500 px-6 py-3 text-sm font-semibold text-white shadow-xl shadow-primary-950/30 drop-shadow-[0_12px_32px_rgba(76,81,255,0.45)] transition hover:translate-y-0.5 hover:shadow-2xl disabled:opacity-60"
         :disabled="!isFormValid || loading"
         @click="handleSubmit"
       >
         Save Item
       </button>
       <button
-        class="w-full bg-gray-200 text-gray-800 font-semibold px-4 py-2 rounded-md hover:bg-gray-300 transition"
+        class="inline-flex flex-1 items-center justify-center rounded-full border border-primary-100 bg-white/90 px-6 py-3 text-sm font-semibold text-primary-700 shadow-md shadow-primary-900/10 transition hover:bg-primary-50/80 disabled:opacity-60"
         :disabled="loading"
         @click="$emit('cancel')"
       >
         Cancel
       </button>
     </div>
+
     <div
       v-if="loading"
-      class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50"
+      class="absolute inset-0 z-10 flex items-center justify-center rounded-3xl bg-[--overlay-bg]"
     >
-      <div class="animate-spin rounded-full h-16 w-16 border-4 border-white border-t-transparent" />
+      <div class="h-12 w-12 animate-spin rounded-full border-4 border-white/80 border-t-transparent" />
     </div>
     <ImageCropper
       :src="cropperSrc"

--- a/src/components/SoldDetailsModal.vue
+++ b/src/components/SoldDetailsModal.vue
@@ -1,12 +1,14 @@
 <template>
   <div
-    class="fixed inset-0 z-50 flex items-center justify-center bg-[--overlay-bg] px-4 py-6 backdrop-blur-sm"
+    class="fixed inset-0 z-[420] overflow-y-auto bg-[--overlay-bg] px-4 py-8 backdrop-blur-sm"
     @click.self="emit('close')"
   >
-    <div class="relative w-full max-w-5xl overflow-hidden rounded-3xl border border-[--ui-border-color] bg-[--ui-bg] p-6 shadow-2xl shadow-gray-950/20 sm:p-10">
+    <div class="relative mx-auto w-full max-w-5xl overflow-hidden rounded-3xl border border-primary-100 bg-gradient-to-br from-white/98 via-primary-50/85 to-white/98 shadow-2xl shadow-primary-900/20 backdrop-blur-2xl ring-1 ring-white/70">
+      <span class="pointer-events-none absolute -right-24 top-16 h-64 w-64 rounded-full bg-primary-200/30 blur-3xl" />
+      <span class="pointer-events-none absolute -left-16 bottom-12 h-56 w-56 rounded-full bg-secondary-200/25 blur-[120px]" />
       <button
         type="button"
-        class="absolute right-6 top-6 inline-flex size-10 items-center justify-center rounded-full border border-transparent bg-[--ui-soft-bg] text-caption transition hover:bg-[--ui-bg] hover:text-title focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+        class="absolute right-6 top-6 inline-flex size-10 items-center justify-center rounded-full border border-white/60 bg-white/85 text-primary-600 shadow-lg shadow-primary-900/15 backdrop-blur transition hover:bg-primary-50/80 hover:text-primary-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
         @click="emit('close')"
       >
         <span class="sr-only">Close</span>
@@ -22,203 +24,213 @@
           <path d="M6 6l12 12M6 18 18 6" />
         </svg>
       </button>
-
-      <div class="max-w-3xl">
-        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-primary-600">
-          Sales Overview
-        </p>
-        <h2 class="mt-2 text-3xl font-semibold text-title">
-          Sold Items Details
-        </h2>
-        <p class="mt-3 text-sm text-caption">
-          Analyze performance across months, stores, and categories to understand how inventory is moving.
-        </p>
-      </div>
-
-      <div class="mt-8 grid gap-4 sm:grid-cols-3">
-        <label class="flex flex-col gap-2 text-sm text-caption">
-          <span class="font-medium text-caption">Month</span>
-          <select
-            v-model="selectedMonth"
-            class="w-full rounded-btn border border-[--ui-border-color] bg-[--ui-soft-bg] px-4 py-2 text-sm text-[--body-text-color] shadow-sm shadow-gray-950/5 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
-          >
-            <option value="">
-              All Months
-            </option>
-            <option
-              v-for="m in months"
-              :key="m"
-              :value="m"
-            >
-              {{ formatMonth(m) }}
-            </option>
-          </select>
-        </label>
-        <label class="flex flex-col gap-2 text-sm text-caption">
-          <span class="font-medium text-caption">Store</span>
-          <select
-            v-model="selectedStore"
-            class="w-full rounded-btn border border-[--ui-border-color] bg-[--ui-soft-bg] px-4 py-2 text-sm text-[--body-text-color] shadow-sm shadow-gray-950/5 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
-          >
-            <option value="">
-              All Stores
-            </option>
-            <option
-              v-for="s in stores"
-              :key="s"
-              :value="s"
-            >
-              {{ s }}
-            </option>
-          </select>
-        </label>
-        <label class="flex flex-col gap-2 text-sm text-caption">
-          <span class="font-medium text-caption">Category</span>
-          <select
-            v-model="selectedCategory"
-            class="w-full rounded-btn border border-[--ui-border-color] bg-[--ui-soft-bg] px-4 py-2 text-sm text-[--body-text-color] shadow-sm shadow-gray-950/5 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
-          >
-            <option value="">
-              All Categories
-            </option>
-            <option
-              v-for="c in categories"
-              :key="c"
-              :value="c"
-            >
-              {{ c }}
-            </option>
-          </select>
-        </label>
-      </div>
-
-      <div class="mt-10 overflow-hidden rounded-2xl border border-[--ui-border-color] shadow-sm shadow-gray-950/10">
-        <div class="border-b border-[--ui-border-color] bg-[--ui-soft-bg] px-6 py-4">
-          <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-caption">
-            Sold Items
-          </h3>
+      <div class="relative max-h-[80vh] overflow-y-auto px-6 pb-10 pt-8 sm:px-10">
+        <div class="max-w-3xl">
+          <p class="text-xs font-semibold uppercase tracking-[0.3em] text-primary-600">
+            Sales Overview
+          </p>
+          <h2 class="mt-2 text-3xl font-semibold text-title text-primary-900">
+            Sold Items Details
+          </h2>
+          <p class="mt-3 text-sm text-primary-600">
+            Analyze performance across months, stores, and categories to understand how inventory is moving.
+          </p>
         </div>
-        <div class="max-h-[320px] overflow-auto">
-          <table class="min-w-full divide-y divide-[--ui-border-color]">
-            <thead class="bg-[--ui-bg]">
-              <tr>
-                <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.2em] text-caption">
-                  Item
-                </th>
-                <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.2em] text-caption">
-                  Sale Dates
-                </th>
-                <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.2em] text-caption">
-                  Days Between Last Sales
-                </th>
-                <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.2em] text-caption">
-                  Price
-                </th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-[--ui-border-color]">
-              <tr
-                v-for="item in filteredSoldItems"
-                :key="item.id"
-                class="transition hover:bg-primary-50/60"
+
+        <div class="mt-8 grid gap-4 sm:grid-cols-3">
+          <label class="flex flex-col gap-2 text-sm text-primary-600">
+            <span class="font-medium text-primary-700">Month</span>
+            <select
+              v-model="selectedMonth"
+              class="w-full rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-sm shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+            >
+              <option value="">
+                All Months
+              </option>
+              <option
+                v-for="m in months"
+                :key="m"
+                :value="m"
               >
-                <td class="px-6 py-4 text-sm font-medium text-title">
-                  {{ item.name }}
-                </td>
-                <td class="px-6 py-4 text-sm text-[--body-text-color]">
-                  <div v-if="item.saleDates && item.saleDates.length" class="space-y-1">
+                {{ formatMonth(m) }}
+              </option>
+            </select>
+          </label>
+          <label class="flex flex-col gap-2 text-sm text-primary-600">
+            <span class="font-medium text-primary-700">Store</span>
+            <select
+              v-model="selectedStore"
+              class="w-full rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-sm shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+            >
+              <option value="">
+                All Stores
+              </option>
+              <option
+                v-for="s in stores"
+                :key="s"
+                :value="s"
+              >
+                {{ s }}
+              </option>
+            </select>
+          </label>
+          <label class="flex flex-col gap-2 text-sm text-primary-600">
+            <span class="font-medium text-primary-700">Category</span>
+            <select
+              v-model="selectedCategory"
+              class="w-full rounded-btn border border-primary-100 bg-white/90 px-4 py-2 text-sm text-[--body-text-color] shadow-sm shadow-primary-900/10 focus:border-primary-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+            >
+              <option value="">
+                All Categories
+              </option>
+              <option
+                v-for="c in categories"
+                :key="c"
+                :value="c"
+              >
+                {{ c }}
+              </option>
+            </select>
+          </label>
+        </div>
+
+        <div class="mt-10 overflow-hidden rounded-2xl border border-primary-100 shadow-lg shadow-primary-900/15">
+          <div class="border-b border-primary-100 bg-white/90 px-6 py-4">
+            <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-primary-600">
+              Sold Items
+            </h3>
+          </div>
+          <div class="max-h-[320px] overflow-auto bg-white/85">
+            <table class="min-w-full divide-y divide-primary-100">
+              <thead class="bg-white/95">
+                <tr>
+                  <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.2em] text-primary-600">
+                    Item
+                  </th>
+                  <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.2em] text-primary-600">
+                    Sale Dates
+                  </th>
+                  <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.2em] text-primary-600">
+                    Days Between Last Sales
+                  </th>
+                  <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.2em] text-primary-600">
+                    Price
+                  </th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-primary-100">
+                <tr
+                  v-for="item in filteredSoldItems"
+                  :key="item.id"
+                  class="transition hover:bg-primary-50/60"
+                >
+                  <td class="px-6 py-4 text-sm font-medium text-title">
+                    {{ item.name }}
+                  </td>
+                  <td class="px-6 py-4 text-sm text-[--body-text-color]">
                     <div
-                      v-for="(d, i) in item.saleDates"
-                      :key="i"
+                      v-if="item.saleDates && item.saleDates.length"
+                      class="space-y-1"
                     >
-                      {{ formatDate(d) }}
+                      <div
+                        v-for="(d, i) in item.saleDates"
+                        :key="i"
+                      >
+                        {{ formatDate(d) }}
+                      </div>
                     </div>
-                  </div>
-                  <span v-else class="text-caption">-</span>
-                </td>
-                <td class="px-6 py-4 text-sm text-[--body-text-color]">
-                  {{ daysBetweenLastSales(item.saleDates) }}
-                </td>
-                <td class="px-6 py-4 text-sm text-[--body-text-color]">
-                  {{ item.price || '-' }}
-                </td>
-              </tr>
-              <tr v-if="!filteredSoldItems.length">
-                <td colspan="4" class="px-6 py-12 text-center text-sm text-caption">
-                  No sold items match the selected filters.
-                </td>
-              </tr>
-            </tbody>
-          </table>
+                    <span
+                      v-else
+                      class="text-primary-500/70"
+                    >-</span>
+                  </td>
+                  <td class="px-6 py-4 text-sm text-[--body-text-color]">
+                    {{ daysBetweenLastSales(item.saleDates) }}
+                  </td>
+                  <td class="px-6 py-4 text-sm text-[--body-text-color]">
+                    {{ item.price || '-' }}
+                  </td>
+                </tr>
+                <tr v-if="!filteredSoldItems.length">
+                  <td
+                    colspan="4"
+                    class="px-6 py-12 text-center text-sm text-primary-600"
+                  >
+                    No sold items match the selected filters.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
         </div>
-      </div>
 
-      <div class="mt-10 grid gap-6 lg:grid-cols-2">
-        <div class="rounded-2xl border border-[--ui-border-color] bg-[--ui-bg] p-6 shadow-sm shadow-gray-950/10">
-          <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-caption">
-            Sales by Store
-          </h3>
-          <ul class="mt-4 space-y-3 text-sm text-[--body-text-color]">
-            <li
-              v-for="s in storeSales"
-              :key="s.store"
-              class="flex items-center justify-between rounded-card bg-[--ui-soft-bg] px-4 py-3 text-sm"
-            >
-              <span class="font-medium text-title">{{ s.store }}</span>
-              <span class="text-caption">{{ s.count }} sold · ${{ s.revenue.toFixed(2) }}</span>
-            </li>
-            <li
-              v-if="!storeSales.length"
-              class="rounded-card bg-[--ui-soft-bg] px-4 py-3 text-sm text-caption"
-            >
-              No store data available.
-            </li>
-          </ul>
+        <div class="mt-10 grid gap-6 lg:grid-cols-2">
+          <div class="rounded-2xl border border-primary-100 bg-white/95 p-6 shadow-lg shadow-primary-900/15 backdrop-blur">
+            <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-primary-600">
+              Sales by Store
+            </h3>
+            <ul class="mt-4 space-y-3 text-sm text-[--body-text-color]">
+              <li
+                v-for="s in storeSales"
+                :key="s.store"
+                class="flex items-center justify-between rounded-card bg-white/90 px-4 py-3 text-sm shadow-inner shadow-primary-900/5"
+              >
+                <span class="font-medium text-primary-800">{{ s.store }}</span>
+                <span class="text-primary-600">{{ s.count }} sold · ${{ s.revenue.toFixed(2) }}</span>
+              </li>
+              <li
+                v-if="!storeSales.length"
+                class="rounded-card bg-white/90 px-4 py-3 text-sm text-primary-600"
+              >
+                No store data available.
+              </li>
+            </ul>
+          </div>
+          <div class="rounded-2xl border border-primary-100 bg-white/95 p-6 shadow-lg shadow-primary-900/15 backdrop-blur">
+            <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-primary-600">
+              Top Sold Items
+            </h3>
+            <ul class="mt-4 space-y-3 text-sm text-[--body-text-color]">
+              <li
+                v-for="ti in topSoldItems"
+                :key="ti.name"
+                class="flex items-center justify-between rounded-card bg-white/90 px-4 py-3 text-sm shadow-inner shadow-primary-900/5"
+              >
+                <span class="font-medium text-primary-800">{{ ti.name }}</span>
+                <span class="text-primary-600">{{ ti.count }} sold</span>
+              </li>
+              <li
+                v-if="!topSoldItems.length"
+                class="rounded-card bg-white/90 px-4 py-3 text-sm text-primary-600"
+              >
+                No top sellers yet.
+              </li>
+            </ul>
+          </div>
         </div>
-        <div class="rounded-2xl border border-[--ui-border-color] bg-[--ui-bg] p-6 shadow-sm shadow-gray-950/10">
-          <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-caption">
-            Top Sold Items
-          </h3>
-          <ul class="mt-4 space-y-3 text-sm text-[--body-text-color]">
-            <li
-              v-for="ti in topSoldItems"
-              :key="ti.name"
-              class="flex items-center justify-between rounded-card bg-[--ui-soft-bg] px-4 py-3 text-sm"
-            >
-              <span class="font-medium text-title">{{ ti.name }}</span>
-              <span class="text-caption">{{ ti.count }} sold</span>
-            </li>
-            <li
-              v-if="!topSoldItems.length"
-              class="rounded-card bg-[--ui-soft-bg] px-4 py-3 text-sm text-caption"
-            >
-              No top sellers yet.
-            </li>
-          </ul>
-        </div>
-      </div>
 
-      <div class="mt-10 rounded-2xl border border-dashed border-[--ui-border-color] bg-[--ui-soft-bg] p-6">
-        <div class="flex items-center justify-between">
-          <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-caption">
-            Sales Chart
-          </h3>
-          <p class="text-xs text-caption">
-            Visualize month-over-month sales momentum.
-          </p>
-        </div>
-        <div class="mt-6 h-64 rounded-card bg-[--ui-bg] p-4 shadow-inner shadow-gray-950/10">
-          <canvas
-            v-if="hasChartData"
-            ref="chartCanvas"
-            class="h-full w-full"
-          ></canvas>
-          <p
-            v-else
-            class="flex h-full items-center justify-center text-center text-sm text-caption"
-          >
-            No sales data available for the selected filters.
-          </p>
+        <div class="mt-10 rounded-2xl border border-dashed border-primary-100 bg-white/95 p-6 shadow-inner shadow-primary-900/10">
+          <div class="flex items-center justify-between">
+            <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-primary-600">
+              Sales Chart
+            </h3>
+            <p class="text-xs text-primary-500">
+              Visualize month-over-month sales momentum.
+            </p>
+          </div>
+          <div class="mt-6 h-64 rounded-card bg-white/95 p-4 shadow-inner shadow-primary-900/10">
+            <canvas
+              v-if="hasChartData"
+              ref="chartCanvas"
+              class="h-full w-full"
+            />
+            <p
+              v-else
+              class="flex h-full items-center justify-center text-center text-sm text-primary-500"
+            >
+              No sales data available for the selected filters.
+            </p>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/SoldDetailsModal.vue
+++ b/src/components/SoldDetailsModal.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="fixed inset-0 z-[420] overflow-y-auto bg-[--overlay-bg] px-4 py-8 backdrop-blur-sm"
+    class="fixed inset-0 z-[720] overflow-y-auto bg-[--overlay-bg] px-4 py-8 backdrop-blur-sm"
     @click.self="emit('close')"
   >
     <div class="relative mx-auto w-full max-w-5xl overflow-hidden rounded-3xl border border-primary-100 bg-gradient-to-br from-white/98 via-primary-50/85 to-white/98 shadow-2xl shadow-primary-900/20 backdrop-blur-2xl ring-1 ring-white/70">

--- a/src/components/StatsDisplay.vue
+++ b/src/components/StatsDisplay.vue
@@ -1,93 +1,104 @@
 <template>
-  <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-    <div class="rounded-card border border-[--ui-border-color] bg-[--ui-bg]/95 p-6 shadow-sm shadow-gray-950/10 backdrop-blur">
-      <p class="text-xs font-semibold uppercase tracking-[0.3em] text-caption">
-        Inventory
-      </p>
-      <p class="mt-4 text-3xl font-semibold text-title">
-        {{ props.stats.items }}
-      </p>
-      <p class="mt-2 text-sm text-caption">
-        Active items in stock
-      </p>
+  <div class="grid gap-5 sm:grid-cols-2 xl:grid-cols-4">
+    <div class="relative overflow-hidden rounded-[26px] bg-gradient-to-br from-[#eef2ff] via-white/95 to-[#e0f2fe] p-6 shadow-[0_32px_90px_-60px_rgba(86,97,255,0.55)] ring-1 ring-white/70 backdrop-blur">
+      <span class="pointer-events-none absolute -right-12 -top-16 h-36 w-36 rounded-full bg-primary-200/50 blur-3xl" />
+      <span class="pointer-events-none absolute -left-12 bottom-0 h-36 w-36 rounded-full bg-secondary-200/50 blur-3xl" />
+      <div class="relative">
+        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-primary-600">
+          Inventory
+        </p>
+        <p class="mt-5 text-4xl font-semibold text-primary-900">
+          {{ props.stats.items }}
+        </p>
+        <p class="mt-2 text-sm text-primary-600">
+          Active items in stock
+        </p>
+      </div>
     </div>
     <button
       type="button"
-      class="group rounded-card border border-[--ui-border-color] bg-[--ui-bg] p-6 text-left shadow-sm shadow-gray-950/10 transition hover:border-primary-300 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+      class="group relative overflow-hidden rounded-[26px] bg-gradient-to-br from-[#e0f2fe] via-[#eef2ff] to-white/95 p-6 text-left shadow-[0_32px_90px_-60px_rgba(86,97,255,0.55)] ring-1 ring-white/70 backdrop-blur transition hover:-translate-y-1 hover:shadow-[0_42px_110px_-60px_rgba(86,97,255,0.72)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
       @click="emit('show-sold-details')"
     >
-      <p class="text-xs font-semibold uppercase tracking-[0.3em] text-caption">
-        Sold
-      </p>
-      <p class="mt-4 flex items-baseline gap-2 text-3xl font-semibold text-title">
-        {{ props.stats.sold }}
-        <span class="text-sm font-medium text-caption">items</span>
-      </p>
-      <div class="mt-5 h-2 w-full rounded-full bg-primary-100">
-        <div
-          class="h-2 rounded-full bg-primary-500 transition-all duration-500"
-          :style="{ width: soldPercent + '%' }"
-        />
+      <span class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,theme(colors.primary.200/0.35),transparent_60%)] opacity-80" />
+      <div class="relative">
+        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-primary-600">
+          Sold
+        </p>
+        <p class="mt-4 flex items-baseline gap-2 text-4xl font-semibold text-primary-900">
+          {{ props.stats.sold }}
+          <span class="text-sm font-medium text-primary-600">items</span>
+        </p>
+        <div class="mt-5 h-2 w-full rounded-full bg-primary-100">
+          <div
+            class="h-2 rounded-full bg-primary-500 transition-all duration-500"
+            :style="{ width: soldPercent + '%' }"
+          />
+        </div>
+        <p class="mt-2 text-xs text-primary-600">
+          {{ soldPercentLabel }}% of inventory sold
+        </p>
+        <span class="mt-4 inline-flex items-center gap-2 text-sm font-medium text-primary-600">
+          View sold insights
+          <svg
+            class="size-4 transition-transform duration-300 group-hover:translate-x-1"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+          >
+            <path d="M5 12h14M13 6l6 6-6 6" />
+          </svg>
+        </span>
       </div>
-      <p class="mt-2 text-xs text-caption">
-        {{ soldPercentLabel }}% of inventory sold
-      </p>
-      <span class="mt-4 inline-flex items-center gap-2 text-sm font-medium text-primary-600">
-        View sold insights
-        <svg
-          class="size-4 transition-transform duration-300 group-hover:translate-x-1"
-          fill="none"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-        >
-          <path d="M5 12h14M13 6l6 6-6 6" />
-        </svg>
-      </span>
     </button>
-    <div class="rounded-card border border-[--ui-border-color] bg-[--ui-bg] p-6 shadow-sm shadow-gray-950/10">
-      <p class="text-xs font-semibold uppercase tracking-[0.3em] text-caption">
-        Paid
-      </p>
-      <p class="mt-4 flex items-baseline gap-2 text-3xl font-semibold text-title">
-        {{ props.stats.sold_paid }}
-        <span class="text-sm font-medium text-caption">items</span>
-      </p>
-      <div class="mt-5 h-2 w-full rounded-full bg-success-100">
-        <div
-          class="h-2 rounded-full bg-success-500 transition-all duration-500"
-          :style="{ width: paidPercent + '%' }"
-        />
+    <div class="relative overflow-hidden rounded-[26px] bg-gradient-to-br from-[#dcfce7] via-white/95 to-[#bbf7d0] p-6 shadow-[0_32px_90px_-60px_rgba(34,197,94,0.4)] ring-1 ring-white/70 backdrop-blur">
+      <span class="pointer-events-none absolute -right-16 top-10 h-32 w-32 rounded-full bg-success-200/50 blur-3xl" />
+      <div class="relative">
+        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-success-600">
+          Paid
+        </p>
+        <p class="mt-4 flex items-baseline gap-2 text-4xl font-semibold text-success-700">
+          {{ props.stats.sold_paid }}
+          <span class="text-sm font-medium text-success-600">items</span>
+        </p>
+        <div class="mt-5 h-2 w-full rounded-full bg-success-100">
+          <div
+            class="h-2 rounded-full bg-success-500 transition-all duration-500"
+            :style="{ width: paidPercent + '%' }"
+          />
+        </div>
+        <p class="mt-2 text-xs text-success-600">
+          {{ paidPercentLabel }}% of sold items paid
+        </p>
       </div>
-      <p class="mt-2 text-xs text-caption">
-        {{ paidPercentLabel }}% of sold items paid
-      </p>
     </div>
     <button
       type="button"
-      class="relative overflow-hidden rounded-card bg-gradient-to-br from-secondary-600 via-primary-600 to-primary-500 p-6 text-left text-white shadow-lg shadow-primary-950/20 transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70"
+      class="relative overflow-hidden rounded-[26px] bg-gradient-to-br from-[#312e81] via-[#4f46e5] to-[#ec4899] p-6 text-left text-white shadow-[0_44px_130px_-60px_rgba(76,81,255,0.8)] drop-shadow-[0_20px_44px_rgba(76,81,255,0.4)] transition hover:-translate-y-1 hover:shadow-[0_52px_150px_-60px_rgba(76,81,255,0.95)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80"
+      :aria-pressed="showOutstanding"
       @click="toggleOutstanding"
     >
-      <span class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,theme(colors.white/0.35),transparent_55%)] opacity-70" />
+      <span class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,theme(colors.white/0.45),transparent_55%)] opacity-80" />
       <div class="relative">
-        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-white/70">
+        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-white/85">
           {{ displayTitle }}
         </p>
-        <p class="mt-4 text-3xl font-semibold">
+        <p class="mt-4 text-4xl font-semibold drop-shadow-[0_6px_18px_rgba(35,30,75,0.55)]">
           ${{ displayValue.toFixed(2) }}
         </p>
-        <div class="mt-5 h-2 w-full rounded-full bg-white/30">
+        <div class="mt-5 h-2 w-full rounded-full bg-white/40">
           <div
-            class="h-2 rounded-full bg-white/90 transition-all duration-500"
+            class="h-2 rounded-full bg-white transition-all duration-500"
             :style="{ width: revenuePercent + '%' }"
           />
         </div>
-        <p class="mt-2 text-xs text-white/80">
+        <p class="mt-2 text-xs font-medium uppercase tracking-[0.2em] text-white/90">
           {{ revenuePercentLabel }}% collected
         </p>
-        <span class="mt-4 inline-flex items-center gap-2 text-sm font-medium">
+        <span class="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-white/90">
           {{ toggleHint }}
           <svg
             class="size-4 transition-transform duration-300"


### PR DESCRIPTION
## Summary
- refresh the dashboard shell with brighter gradients, higher z-index navigation, and a reusable scroll lock helper so the menu and overlays reliably float above the interface
- retune the stats tiles with more saturated backgrounds and larger typography to keep paid totals and other metrics readable at a glance
- let add/edit/contact/export modals scroll within the viewport with taller glassmorphism shells and matching rings for a cohesive colored theme

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ceaa595df48320bd9be458242524c1