### PR TITLE
Improve note image handling and sync recovery

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -21,6 +21,7 @@
     --color-blue-500: oklch(62.3% 0.214 259.815);
     --color-blue-600: oklch(54.6% 0.245 262.881);
     --color-blue-700: oklch(48.8% 0.243 264.376);
+    --color-indigo-500: oklch(58.5% 0.233 277.117);
     --color-purple-500: oklch(62.7% 0.265 303.9);
     --color-purple-600: oklch(55.8% 0.288 302.321);
     --color-purple-700: oklch(49.6% 0.265 301.924);
@@ -53,13 +54,16 @@
     --container-md: 28rem;
     --container-lg: 32rem;
     --container-xl: 36rem;
+    --container-2xl: 42rem;
     --container-3xl: 48rem;
     --container-5xl: 64rem;
-    --container-7xl: 80rem;
+    --container-6xl: 72rem;
     --text-xs: 0.75rem;
     --text-xs--line-height: calc(1 / 0.75);
     --text-sm: 0.875rem;
     --text-sm--line-height: calc(1.25 / 0.875);
+    --text-base: 1rem;
+    --text-base--line-height: calc(1.5 / 1);
     --text-lg: 1.125rem;
     --text-lg--line-height: calc(1.75 / 1.125);
     --text-xl: 1.25rem;
@@ -68,6 +72,8 @@
     --text-2xl--line-height: calc(2 / 1.5);
     --text-3xl: 1.875rem;
     --text-3xl--line-height: calc(2.25 / 1.875);
+    --text-4xl: 2.25rem;
+    --text-4xl--line-height: calc(2.5 / 2.25);
     --font-weight-normal: 400;
     --font-weight-medium: 500;
     --font-weight-semibold: 600;
@@ -83,6 +89,9 @@
     --radius-3xl: 1.5rem;
     --animate-spin: spin 1s linear infinite;
     --blur-sm: 8px;
+    --blur-xl: 24px;
+    --blur-2xl: 40px;
+    --blur-3xl: 64px;
     --default-transition-duration: 150ms;
     --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     --default-font-family: var(--font-sans);
@@ -322,14 +331,59 @@
   .inset-0 {
     inset: calc(var(--spacing) * 0);
   }
+  .-top-16 {
+    top: calc(var(--spacing) * -16);
+  }
+  .-top-36 {
+    top: calc(var(--spacing) * -36);
+  }
   .top-0 {
     top: calc(var(--spacing) * 0);
   }
   .top-2 {
     top: calc(var(--spacing) * 2);
   }
+  .top-5 {
+    top: calc(var(--spacing) * 5);
+  }
   .top-6 {
     top: calc(var(--spacing) * 6);
+  }
+  .top-10 {
+    top: calc(var(--spacing) * 10);
+  }
+  .top-12 {
+    top: calc(var(--spacing) * 12);
+  }
+  .top-16 {
+    top: calc(var(--spacing) * 16);
+  }
+  .top-24 {
+    top: calc(var(--spacing) * 24);
+  }
+  .top-full {
+    top: 100%;
+  }
+  .-right-12 {
+    right: calc(var(--spacing) * -12);
+  }
+  .-right-14 {
+    right: calc(var(--spacing) * -14);
+  }
+  .-right-16 {
+    right: calc(var(--spacing) * -16);
+  }
+  .-right-20 {
+    right: calc(var(--spacing) * -20);
+  }
+  .-right-24 {
+    right: calc(var(--spacing) * -24);
+  }
+  .-right-28 {
+    right: calc(var(--spacing) * -28);
+  }
+  .-right-40 {
+    right: calc(var(--spacing) * -40);
   }
   .right-0 {
     right: calc(var(--spacing) * 0);
@@ -337,8 +391,41 @@
   .right-2 {
     right: calc(var(--spacing) * 2);
   }
+  .right-5 {
+    right: calc(var(--spacing) * 5);
+  }
   .right-6 {
     right: calc(var(--spacing) * 6);
+  }
+  .bottom-0 {
+    bottom: calc(var(--spacing) * 0);
+  }
+  .bottom-2 {
+    bottom: calc(var(--spacing) * 2);
+  }
+  .bottom-6 {
+    bottom: calc(var(--spacing) * 6);
+  }
+  .bottom-12 {
+    bottom: calc(var(--spacing) * 12);
+  }
+  .bottom-28 {
+    bottom: calc(var(--spacing) * 28);
+  }
+  .-left-12 {
+    left: calc(var(--spacing) * -12);
+  }
+  .-left-16 {
+    left: calc(var(--spacing) * -16);
+  }
+  .-left-20 {
+    left: calc(var(--spacing) * -20);
+  }
+  .-left-28 {
+    left: calc(var(--spacing) * -28);
+  }
+  .-left-40 {
+    left: calc(var(--spacing) * -40);
   }
   .left-0 {
     left: calc(var(--spacing) * 0);
@@ -349,11 +436,20 @@
   .z-20 {
     z-index: 20;
   }
-  .z-40 {
-    z-index: 40;
+  .z-\[950\] {
+    z-index: 950;
   }
-  .z-50 {
-    z-index: 50;
+  .z-\[1200\] {
+    z-index: 1200;
+  }
+  .z-\[1250\] {
+    z-index: 1250;
+  }
+  .z-\[1300\] {
+    z-index: 1300;
+  }
+  .z-\[1600\] {
+    z-index: 1600;
   }
   .container {
     width: 100%;
@@ -379,8 +475,8 @@
   .mx-auto {
     margin-inline: auto;
   }
-  .my-2 {
-    margin-block: calc(var(--spacing) * 2);
+  .my-3 {
+    margin-block: calc(var(--spacing) * 3);
   }
   .mt-1 {
     margin-top: calc(var(--spacing) * 1);
@@ -445,6 +541,9 @@
   .grid {
     display: grid;
   }
+  .hidden {
+    display: none;
+  }
   .inline-flex {
     display: inline-flex;
   }
@@ -459,13 +558,17 @@
     width: calc(var(--spacing) * 5);
     height: calc(var(--spacing) * 5);
   }
+  .size-9 {
+    width: calc(var(--spacing) * 9);
+    height: calc(var(--spacing) * 9);
+  }
   .size-10 {
     width: calc(var(--spacing) * 10);
     height: calc(var(--spacing) * 10);
   }
-  .size-14 {
-    width: calc(var(--spacing) * 14);
-    height: calc(var(--spacing) * 14);
+  .size-16 {
+    width: calc(var(--spacing) * 16);
+    height: calc(var(--spacing) * 16);
   }
   .h-2 {
     height: calc(var(--spacing) * 2);
@@ -479,20 +582,41 @@
   .h-12 {
     height: calc(var(--spacing) * 12);
   }
-  .h-16 {
-    height: calc(var(--spacing) * 16);
-  }
   .h-24 {
     height: calc(var(--spacing) * 24);
+  }
+  .h-32 {
+    height: calc(var(--spacing) * 32);
+  }
+  .h-36 {
+    height: calc(var(--spacing) * 36);
   }
   .h-48 {
     height: calc(var(--spacing) * 48);
   }
+  .h-56 {
+    height: calc(var(--spacing) * 56);
+  }
+  .h-60 {
+    height: calc(var(--spacing) * 60);
+  }
   .h-64 {
     height: calc(var(--spacing) * 64);
   }
+  .h-72 {
+    height: calc(var(--spacing) * 72);
+  }
   .h-\[3\.5rem\] {
     height: 3.5rem;
+  }
+  .h-\[20rem\] {
+    height: 20rem;
+  }
+  .h-\[22rem\] {
+    height: 22rem;
+  }
+  .h-\[26rem\] {
+    height: 26rem;
   }
   .h-full {
     height: 100%;
@@ -500,17 +624,26 @@
   .h-px {
     height: 1px;
   }
-  .max-h-40 {
-    max-height: calc(var(--spacing) * 40);
+  .max-h-48 {
+    max-height: calc(var(--spacing) * 48);
   }
-  .max-h-\[90vh\] {
-    max-height: 90vh;
+  .max-h-\[80vh\] {
+    max-height: 80vh;
   }
   .max-h-\[320px\] {
     max-height: 320px;
   }
+  .max-h-\[calc\(100vh-4rem\)\] {
+    max-height: calc(100vh - 4rem);
+  }
   .max-h-screen {
     max-height: 100vh;
+  }
+  .min-h-24 {
+    min-height: calc(var(--spacing) * 24);
+  }
+  .min-h-32 {
+    min-height: calc(var(--spacing) * 32);
   }
   .min-h-screen {
     min-height: 100vh;
@@ -524,20 +657,38 @@
   .w-12 {
     width: calc(var(--spacing) * 12);
   }
-  .w-16 {
-    width: calc(var(--spacing) * 16);
-  }
   .w-24 {
     width: calc(var(--spacing) * 24);
+  }
+  .w-32 {
+    width: calc(var(--spacing) * 32);
+  }
+  .w-36 {
+    width: calc(var(--spacing) * 36);
+  }
+  .w-48 {
+    width: calc(var(--spacing) * 48);
+  }
+  .w-56 {
+    width: calc(var(--spacing) * 56);
+  }
+  .w-60 {
+    width: calc(var(--spacing) * 60);
   }
   .w-64 {
     width: calc(var(--spacing) * 64);
   }
-  .w-80 {
-    width: calc(var(--spacing) * 80);
+  .w-72 {
+    width: calc(var(--spacing) * 72);
   }
-  .w-96 {
-    width: calc(var(--spacing) * 96);
+  .w-\[20rem\] {
+    width: 20rem;
+  }
+  .w-\[22rem\] {
+    width: 22rem;
+  }
+  .w-\[26rem\] {
+    width: 26rem;
   }
   .w-auto {
     width: auto;
@@ -545,17 +696,17 @@
   .w-full {
     width: 100%;
   }
+  .max-w-2xl {
+    max-width: var(--container-2xl);
+  }
   .max-w-3xl {
     max-width: var(--container-3xl);
   }
   .max-w-5xl {
     max-width: var(--container-5xl);
   }
-  .max-w-7xl {
-    max-width: var(--container-7xl);
-  }
-  .max-w-full {
-    max-width: 100%;
+  .max-w-6xl {
+    max-width: var(--container-6xl);
   }
   .max-w-lg {
     max-width: var(--container-lg);
@@ -650,11 +801,14 @@
   .gap-4 {
     gap: calc(var(--spacing) * 4);
   }
+  .gap-5 {
+    gap: calc(var(--spacing) * 5);
+  }
   .gap-6 {
     gap: calc(var(--spacing) * 6);
   }
-  .gap-8 {
-    gap: calc(var(--spacing) * 8);
+  .gap-10 {
+    gap: calc(var(--spacing) * 10);
   }
   .space-y-1 {
     :where(& > :not(:last-child)) {
@@ -675,6 +829,13 @@
       --tw-space-y-reverse: 0;
       margin-block-start: calc(calc(var(--spacing) * 3) * var(--tw-space-y-reverse));
       margin-block-end: calc(calc(var(--spacing) * 3) * calc(1 - var(--tw-space-y-reverse)));
+    }
+  }
+  .space-y-6 {
+    :where(& > :not(:last-child)) {
+      --tw-space-y-reverse: 0;
+      margin-block-start: calc(calc(var(--spacing) * 6) * var(--tw-space-y-reverse));
+      margin-block-end: calc(calc(var(--spacing) * 6) * calc(1 - var(--tw-space-y-reverse)));
     }
   }
   .space-y-8 {
@@ -707,11 +868,6 @@
       border-bottom-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
     }
   }
-  .divide-\[--ui-border-color\] {
-    :where(& > :not(:last-child)) {
-      border-color: --ui-border-color;
-    }
-  }
   .divide-gray-200 {
     :where(& > :not(:last-child)) {
       border-color: var(--color-gray-200);
@@ -723,8 +879,14 @@
   .overflow-hidden {
     overflow: hidden;
   }
+  .overflow-visible {
+    overflow: visible;
+  }
   .overflow-x-auto {
     overflow-x: auto;
+  }
+  .overflow-x-hidden {
+    overflow-x: hidden;
   }
   .overflow-y-auto {
     overflow-y: auto;
@@ -737,6 +899,21 @@
   }
   .rounded-3xl {
     border-radius: var(--radius-3xl);
+  }
+  .rounded-\[26px\] {
+    border-radius: 26px;
+  }
+  .rounded-\[28px\] {
+    border-radius: 28px;
+  }
+  .rounded-\[30px\] {
+    border-radius: 30px;
+  }
+  .rounded-\[34px\] {
+    border-radius: 34px;
+  }
+  .rounded-\[38px\] {
+    border-radius: 38px;
   }
   .rounded-full {
     border-radius: calc(infinity * 1px);
@@ -772,9 +949,6 @@
     --tw-border-style: dashed;
     border-style: dashed;
   }
-  .border-\[--ui-border-color\] {
-    border-color: --ui-border-color;
-  }
   .border-gray-200 {
     border-color: var(--color-gray-200);
   }
@@ -784,11 +958,17 @@
   .border-purple-500 {
     border-color: var(--color-purple-500);
   }
-  .border-transparent {
-    border-color: transparent;
+  .border-white\/60 {
+    border-color: color-mix(in srgb, #fff 60%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--color-white) 60%, transparent);
+    }
   }
-  .border-white {
-    border-color: var(--color-white);
+  .border-white\/80 {
+    border-color: color-mix(in srgb, #fff 80%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--color-white) 80%, transparent);
+    }
   }
   .border-t-transparent {
     border-top-color: transparent;
@@ -796,29 +976,8 @@
   .bg-\[--overlay-bg\] {
     background-color: --overlay-bg;
   }
-  .bg-\[--ui-bg\] {
-    background-color: --ui-bg;
-  }
-  .bg-\[--ui-bg\]\/80 {
-    background-color: color-mix(in oklab, --ui-bg 80%, transparent);
-  }
-  .bg-\[--ui-bg\]\/95 {
-    background-color: color-mix(in oklab, --ui-bg 95%, transparent);
-  }
-  .bg-\[--ui-border-color\] {
-    background-color: --ui-border-color;
-  }
-  .bg-\[--ui-soft-bg\] {
-    background-color: --ui-soft-bg;
-  }
   .bg-black {
     background-color: var(--color-black);
-  }
-  .bg-black\/30 {
-    background-color: color-mix(in srgb, #000 30%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      background-color: color-mix(in oklab, var(--color-black) 30%, transparent);
-    }
   }
   .bg-blue-500 {
     background-color: var(--color-blue-500);
@@ -850,16 +1009,46 @@
   .bg-white {
     background-color: var(--color-white);
   }
-  .bg-white\/30 {
-    background-color: color-mix(in srgb, #fff 30%, transparent);
+  .bg-white\/40 {
+    background-color: color-mix(in srgb, #fff 40%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
-      background-color: color-mix(in oklab, var(--color-white) 30%, transparent);
+      background-color: color-mix(in oklab, var(--color-white) 40%, transparent);
+    }
+  }
+  .bg-white\/60 {
+    background-color: color-mix(in srgb, #fff 60%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-white) 60%, transparent);
+    }
+  }
+  .bg-white\/75 {
+    background-color: color-mix(in srgb, #fff 75%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-white) 75%, transparent);
+    }
+  }
+  .bg-white\/80 {
+    background-color: color-mix(in srgb, #fff 80%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-white) 80%, transparent);
+    }
+  }
+  .bg-white\/85 {
+    background-color: color-mix(in srgb, #fff 85%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-white) 85%, transparent);
     }
   }
   .bg-white\/90 {
     background-color: color-mix(in srgb, #fff 90%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       background-color: color-mix(in oklab, var(--color-white) 90%, transparent);
+    }
+  }
+  .bg-white\/95 {
+    background-color: color-mix(in srgb, #fff 95%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-white) 95%, transparent);
     }
   }
   .bg-yellow-100 {
@@ -873,15 +1062,148 @@
     --tw-gradient-position: to right in oklab;
     background-image: linear-gradient(var(--tw-gradient-stops));
   }
-  .bg-\[radial-gradient\(circle_at_top\,theme\(colors\.white\/0\.35\)\,transparent_55\%\)\] {
-    background-image: radial-gradient(circle at top,color-mix(in oklab, #fff 35%, transparent),transparent 55%);
+  .bg-\[radial-gradient\(circle_at_top\,theme\(colors\.white\/0\.45\)\,transparent_55\%\)\] {
+    background-image: radial-gradient(circle at top,color-mix(in oklab, #fff 45%, transparent),transparent 55%);
+  }
+  .from-\[\#4f46e5\] {
+    --tw-gradient-from: #4f46e5;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+  .from-\[\#312e81\] {
+    --tw-gradient-from: #312e81;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+  .from-\[\#dcfce7\] {
+    --tw-gradient-from: #dcfce7;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+  .from-\[\#e0f2fe\] {
+    --tw-gradient-from: #e0f2fe;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+  .from-\[\#eef2ff\] {
+    --tw-gradient-from: #eef2ff;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .from-purple-600 {
     --tw-gradient-from: var(--color-purple-600);
     --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
+  .from-white\/88 {
+    --tw-gradient-from: color-mix(in srgb, #fff 88%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-gradient-from: color-mix(in oklab, var(--color-white) 88%, transparent);
+    }
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+  .from-white\/92 {
+    --tw-gradient-from: color-mix(in srgb, #fff 92%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-gradient-from: color-mix(in oklab, var(--color-white) 92%, transparent);
+    }
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+  .from-white\/98 {
+    --tw-gradient-from: color-mix(in srgb, #fff 98%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-gradient-from: color-mix(in oklab, var(--color-white) 98%, transparent);
+    }
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+  .via-\[\#4f46e5\] {
+    --tw-gradient-via: #4f46e5;
+    --tw-gradient-via-stops: var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-via) var(--tw-gradient-via-position), var(--tw-gradient-to) var(--tw-gradient-to-position);
+    --tw-gradient-stops: var(--tw-gradient-via-stops);
+  }
+  .via-\[\#7c3aed\] {
+    --tw-gradient-via: #7c3aed;
+    --tw-gradient-via-stops: var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-via) var(--tw-gradient-via-position), var(--tw-gradient-to) var(--tw-gradient-to-position);
+    --tw-gradient-stops: var(--tw-gradient-via-stops);
+  }
+  .via-\[\#eef2ff\] {
+    --tw-gradient-via: #eef2ff;
+    --tw-gradient-via-stops: var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-via) var(--tw-gradient-via-position), var(--tw-gradient-to) var(--tw-gradient-to-position);
+    --tw-gradient-stops: var(--tw-gradient-via-stops);
+  }
+  .via-indigo-500 {
+    --tw-gradient-via: var(--color-indigo-500);
+    --tw-gradient-via-stops: var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-via) var(--tw-gradient-via-position), var(--tw-gradient-to) var(--tw-gradient-to-position);
+    --tw-gradient-stops: var(--tw-gradient-via-stops);
+  }
+  .via-white {
+    --tw-gradient-via: var(--color-white);
+    --tw-gradient-via-stops: var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-via) var(--tw-gradient-via-position), var(--tw-gradient-to) var(--tw-gradient-to-position);
+    --tw-gradient-stops: var(--tw-gradient-via-stops);
+  }
+  .via-white\/85 {
+    --tw-gradient-via: color-mix(in srgb, #fff 85%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-gradient-via: color-mix(in oklab, var(--color-white) 85%, transparent);
+    }
+    --tw-gradient-via-stops: var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-via) var(--tw-gradient-via-position), var(--tw-gradient-to) var(--tw-gradient-to-position);
+    --tw-gradient-stops: var(--tw-gradient-via-stops);
+  }
+  .via-white\/95 {
+    --tw-gradient-via: color-mix(in srgb, #fff 95%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-gradient-via: color-mix(in oklab, var(--color-white) 95%, transparent);
+    }
+    --tw-gradient-via-stops: var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-via) var(--tw-gradient-via-position), var(--tw-gradient-to) var(--tw-gradient-to-position);
+    --tw-gradient-stops: var(--tw-gradient-via-stops);
+  }
+  .to-\[\#bbf7d0\] {
+    --tw-gradient-to: #bbf7d0;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+  .to-\[\#e0f2fe\] {
+    --tw-gradient-to: #e0f2fe;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+  .to-\[\#ec4899\] {
+    --tw-gradient-to: #ec4899;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+  .to-\[\#fdf4ff\] {
+    --tw-gradient-to: #fdf4ff;
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
   .to-pink-500 {
     --tw-gradient-to: var(--color-pink-500);
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+  .to-white\/88 {
+    --tw-gradient-to: color-mix(in srgb, #fff 88%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-gradient-to: color-mix(in oklab, var(--color-white) 88%, transparent);
+    }
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+  .to-white\/90 {
+    --tw-gradient-to: color-mix(in srgb, #fff 90%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-gradient-to: color-mix(in oklab, var(--color-white) 90%, transparent);
+    }
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+  .to-white\/92 {
+    --tw-gradient-to: color-mix(in srgb, #fff 92%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-gradient-to: color-mix(in oklab, var(--color-white) 92%, transparent);
+    }
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+  .to-white\/95 {
+    --tw-gradient-to: color-mix(in srgb, #fff 95%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-gradient-to: color-mix(in oklab, var(--color-white) 95%, transparent);
+    }
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+  .to-white\/98 {
+    --tw-gradient-to: color-mix(in srgb, #fff 98%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-gradient-to: color-mix(in oklab, var(--color-white) 98%, transparent);
+    }
     --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .object-contain {
@@ -901,6 +1223,9 @@
   .p-6 {
     padding: calc(var(--spacing) * 6);
   }
+  .p-9 {
+    padding: calc(var(--spacing) * 9);
+  }
   .px-1 {
     padding-inline: calc(var(--spacing) * 1);
   }
@@ -919,6 +1244,9 @@
   .px-6 {
     padding-inline: calc(var(--spacing) * 6);
   }
+  .px-8 {
+    padding-inline: calc(var(--spacing) * 8);
+  }
   .px-10 {
     padding-inline: calc(var(--spacing) * 10);
   }
@@ -934,6 +1262,9 @@
   .py-3 {
     padding-block: calc(var(--spacing) * 3);
   }
+  .py-3\.5 {
+    padding-block: calc(var(--spacing) * 3.5);
+  }
   .py-4 {
     padding-block: calc(var(--spacing) * 4);
   }
@@ -943,14 +1274,26 @@
   .py-8 {
     padding-block: calc(var(--spacing) * 8);
   }
-  .py-10 {
-    padding-block: calc(var(--spacing) * 10);
-  }
   .py-12 {
     padding-block: calc(var(--spacing) * 12);
   }
+  .py-14 {
+    padding-block: calc(var(--spacing) * 14);
+  }
+  .pt-8 {
+    padding-top: calc(var(--spacing) * 8);
+  }
   .pb-4 {
     padding-bottom: calc(var(--spacing) * 4);
+  }
+  .pb-6 {
+    padding-bottom: calc(var(--spacing) * 6);
+  }
+  .pb-10 {
+    padding-bottom: calc(var(--spacing) * 10);
+  }
+  .pb-16 {
+    padding-bottom: calc(var(--spacing) * 16);
   }
   .text-center {
     text-align: center;
@@ -971,6 +1314,14 @@
   .text-3xl {
     font-size: var(--text-3xl);
     line-height: var(--tw-leading, var(--text-3xl--line-height));
+  }
+  .text-4xl {
+    font-size: var(--text-4xl);
+    line-height: var(--tw-leading, var(--text-4xl--line-height));
+  }
+  .text-base {
+    font-size: var(--text-base);
+    line-height: var(--tw-leading, var(--text-base--line-height));
   }
   .text-lg {
     font-size: var(--text-lg);
@@ -1084,16 +1435,16 @@
   .text-white {
     color: var(--color-white);
   }
-  .text-white\/70 {
-    color: color-mix(in srgb, #fff 70%, transparent);
+  .text-white\/85 {
+    color: color-mix(in srgb, #fff 85%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
-      color: color-mix(in oklab, var(--color-white) 70%, transparent);
+      color: color-mix(in oklab, var(--color-white) 85%, transparent);
     }
   }
-  .text-white\/80 {
-    color: color-mix(in srgb, #fff 80%, transparent);
+  .text-white\/90 {
+    color: color-mix(in srgb, #fff 90%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
-      color: color-mix(in oklab, var(--color-white) 80%, transparent);
+      color: color-mix(in oklab, var(--color-white) 90%, transparent);
     }
   }
   .text-yellow-800 {
@@ -1108,11 +1459,11 @@
   .opacity-25 {
     opacity: 25%;
   }
-  .opacity-70 {
-    opacity: 70%;
-  }
   .opacity-75 {
     opacity: 75%;
+  }
+  .opacity-80 {
+    opacity: 80%;
   }
   .shadow {
     --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
@@ -1120,6 +1471,78 @@
   }
   .shadow-2xl {
     --tw-shadow: 0 25px 50px -12px var(--tw-shadow-color, rgb(0 0 0 / 0.25));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-\[0_12px_30px_-18px_rgba\(217\,119\,6\,0\.5\)\] {
+    --tw-shadow: 0 12px 30px -18px var(--tw-shadow-color, rgba(217,119,6,0.5));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-\[0_12px_30px_-18px_rgba\(220\,38\,38\,0\.45\)\] {
+    --tw-shadow: 0 12px 30px -18px var(--tw-shadow-color, rgba(220,38,38,0.45));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-\[0_18px_40px_-28px_rgba\(71\,80\,255\,0\.9\)\] {
+    --tw-shadow: 0 18px 40px -28px var(--tw-shadow-color, rgba(71,80,255,0.9));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-\[0_18px_40px_-28px_rgba\(86\,96\,255\,0\.7\)\] {
+    --tw-shadow: 0 18px 40px -28px var(--tw-shadow-color, rgba(86,96,255,0.7));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-\[0_26px_60px_-32px_rgba\(68\,64\,200\,0\.9\)\] {
+    --tw-shadow: 0 26px 60px -32px var(--tw-shadow-color, rgba(68,64,200,0.9));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-\[0_26px_60px_-32px_rgba\(68\,64\,200\,0\.85\)\] {
+    --tw-shadow: 0 26px 60px -32px var(--tw-shadow-color, rgba(68,64,200,0.85));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-\[0_30px_80px_-38px_rgba\(68\,64\,200\,0\.85\)\] {
+    --tw-shadow: 0 30px 80px -38px var(--tw-shadow-color, rgba(68,64,200,0.85));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-\[0_30px_85px_-55px_rgba\(88\,100\,255\,0\.55\)\] {
+    --tw-shadow: 0 30px 85px -55px var(--tw-shadow-color, rgba(88,100,255,0.55));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-\[0_32px_90px_-60px_rgba\(34\,197\,94\,0\.4\)\] {
+    --tw-shadow: 0 32px 90px -60px var(--tw-shadow-color, rgba(34,197,94,0.4));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-\[0_32px_90px_-60px_rgba\(86\,97\,255\,0\.55\)\] {
+    --tw-shadow: 0 32px 90px -60px var(--tw-shadow-color, rgba(86,97,255,0.55));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-\[0_32px_95px_-58px_rgba\(88\,100\,255\,0\.6\)\] {
+    --tw-shadow: 0 32px 95px -58px var(--tw-shadow-color, rgba(88,100,255,0.6));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-\[0_36px_90px_-40px_rgba\(70\,74\,255\,0\.55\)\] {
+    --tw-shadow: 0 36px 90px -40px var(--tw-shadow-color, rgba(70,74,255,0.55));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-\[0_42px_120px_-64px_rgba\(88\,100\,255\,0\.6\)\] {
+    --tw-shadow: 0 42px 120px -64px var(--tw-shadow-color, rgba(88,100,255,0.6));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-\[0_44px_130px_-60px_rgba\(76\,81\,255\,0\.8\)\] {
+    --tw-shadow: 0 44px 130px -60px var(--tw-shadow-color, rgba(76,81,255,0.8));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-\[0_48px_120px_-60px_rgba\(90\,104\,255\,0\.55\)\] {
+    --tw-shadow: 0 48px 120px -60px var(--tw-shadow-color, rgba(90,104,255,0.55));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-\[inset_0_0_0_1px_rgba\(120\,133\,255\,0\.12\)\] {
+    --tw-shadow: inset 0 0 0 1px var(--tw-shadow-color, rgba(120,133,255,0.12));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-\[inset_0_0_0_1px_rgba\(120\,133\,255\,0\.16\)\] {
+    --tw-shadow: inset 0 0 0 1px var(--tw-shadow-color, rgba(120,133,255,0.16));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-\[inset_0_0_0_1px_rgba\(120\,133\,255\,0\.18\)\] {
+    --tw-shadow: inset 0 0 0 1px var(--tw-shadow-color, rgba(120,133,255,0.18));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
   .shadow-inner {
@@ -1146,22 +1569,20 @@
     --tw-shadow: 0 20px 25px -5px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 8px 10px -6px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
-  .shadow-gray-950\/5 {
-    --tw-shadow-color: color-mix(in srgb, oklch(13% 0.028 261.692) 5%, transparent);
+  .ring-1 {
+    --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .ring-white\/60 {
+    --tw-ring-color: color-mix(in srgb, #fff 60%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
-      --tw-shadow-color: color-mix(in oklab, color-mix(in oklab, var(--color-gray-950) 5%, transparent) var(--tw-shadow-alpha), transparent);
+      --tw-ring-color: color-mix(in oklab, var(--color-white) 60%, transparent);
     }
   }
-  .shadow-gray-950\/10 {
-    --tw-shadow-color: color-mix(in srgb, oklch(13% 0.028 261.692) 10%, transparent);
+  .ring-white\/70 {
+    --tw-ring-color: color-mix(in srgb, #fff 70%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
-      --tw-shadow-color: color-mix(in oklab, color-mix(in oklab, var(--color-gray-950) 10%, transparent) var(--tw-shadow-alpha), transparent);
-    }
-  }
-  .shadow-gray-950\/20 {
-    --tw-shadow-color: color-mix(in srgb, oklch(13% 0.028 261.692) 20%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      --tw-shadow-color: color-mix(in oklab, color-mix(in oklab, var(--color-gray-950) 20%, transparent) var(--tw-shadow-alpha), transparent);
+      --tw-ring-color: color-mix(in oklab, var(--color-white) 70%, transparent);
     }
   }
   .outline-hidden {
@@ -1180,6 +1601,50 @@
     --tw-blur: blur(8px);
     filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
   }
+  .blur-3xl {
+    --tw-blur: blur(var(--blur-3xl));
+    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+  }
+  .blur-\[120px\] {
+    --tw-blur: blur(120px);
+    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+  }
+  .blur-\[130px\] {
+    --tw-blur: blur(130px);
+    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+  }
+  .blur-\[140px\] {
+    --tw-blur: blur(140px);
+    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+  }
+  .blur-\[150px\] {
+    --tw-blur: blur(150px);
+    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+  }
+  .blur-\[160px\] {
+    --tw-blur: blur(160px);
+    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+  }
+  .drop-shadow-\[0_6px_18px_rgba\(35\,30\,75\,0\.55\)\] {
+    --tw-drop-shadow-size: drop-shadow(0 6px 18px var(--tw-drop-shadow-color, rgba(35,30,75,0.55)));
+    --tw-drop-shadow: var(--tw-drop-shadow-size);
+    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+  }
+  .drop-shadow-\[0_12px_32px_rgba\(76\,81\,255\,0\.45\)\] {
+    --tw-drop-shadow-size: drop-shadow(0 12px 32px var(--tw-drop-shadow-color, rgba(76,81,255,0.45)));
+    --tw-drop-shadow: var(--tw-drop-shadow-size);
+    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+  }
+  .drop-shadow-\[0_14px_32px_rgba\(76\,81\,255\,0\.45\)\] {
+    --tw-drop-shadow-size: drop-shadow(0 14px 32px var(--tw-drop-shadow-color, rgba(76,81,255,0.45)));
+    --tw-drop-shadow: var(--tw-drop-shadow-size);
+    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+  }
+  .drop-shadow-\[0_20px_44px_rgba\(76\,81\,255\,0\.4\)\] {
+    --tw-drop-shadow-size: drop-shadow(0 20px 44px var(--tw-drop-shadow-color, rgba(76,81,255,0.4)));
+    --tw-drop-shadow: var(--tw-drop-shadow-size);
+    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+  }
   .filter {
     filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
   }
@@ -1188,8 +1653,18 @@
     -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
     backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
   }
+  .backdrop-blur-2xl {
+    --tw-backdrop-blur: blur(var(--blur-2xl));
+    -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+    backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+  }
   .backdrop-blur-sm {
     --tw-backdrop-blur: blur(var(--blur-sm));
+    -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+    backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+  }
+  .backdrop-blur-xl {
+    --tw-backdrop-blur: blur(var(--blur-xl));
     -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
     backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
   }
@@ -1230,17 +1705,27 @@
       border-bottom-width: 0px;
     }
   }
-  .hover\:bg-\[--ui-bg\] {
+  .hover\:-translate-y-0\.5 {
     &:hover {
       @media (hover: hover) {
-        background-color: --ui-bg;
+        --tw-translate-y: calc(var(--spacing) * -0.5);
+        translate: var(--tw-translate-x) var(--tw-translate-y);
       }
     }
   }
-  .hover\:bg-\[--ui-soft-bg\] {
+  .hover\:-translate-y-1 {
     &:hover {
       @media (hover: hover) {
-        background-color: --ui-soft-bg;
+        --tw-translate-y: calc(var(--spacing) * -1);
+        translate: var(--tw-translate-x) var(--tw-translate-y);
+      }
+    }
+  }
+  .hover\:translate-y-0\.5 {
+    &:hover {
+      @media (hover: hover) {
+        --tw-translate-y: calc(var(--spacing) * 0.5);
+        translate: var(--tw-translate-x) var(--tw-translate-y);
       }
     }
   }
@@ -1286,6 +1771,15 @@
       }
     }
   }
+  .hover\:via-indigo-500 {
+    &:hover {
+      @media (hover: hover) {
+        --tw-gradient-via: var(--color-indigo-500);
+        --tw-gradient-via-stops: var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-via) var(--tw-gradient-via-position), var(--tw-gradient-to) var(--tw-gradient-to-position);
+        --tw-gradient-stops: var(--tw-gradient-via-stops);
+      }
+    }
+  }
   .hover\:text-blue-700 {
     &:hover {
       @media (hover: hover) {
@@ -1328,19 +1822,59 @@
       }
     }
   }
-  .hover\:shadow-lg {
+  .hover\:shadow-2xl {
     &:hover {
       @media (hover: hover) {
-        --tw-shadow: 0 10px 15px -3px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 4px 6px -4px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+        --tw-shadow: 0 25px 50px -12px var(--tw-shadow-color, rgb(0 0 0 / 0.25));
         box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
       }
     }
   }
-  .hover\:brightness-110 {
+  .hover\:shadow-\[0_26px_55px_-32px_rgba\(86\,96\,255\,0\.75\)\] {
     &:hover {
       @media (hover: hover) {
-        --tw-brightness: brightness(110%);
-        filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+        --tw-shadow: 0 26px 55px -32px var(--tw-shadow-color, rgba(86,96,255,0.75));
+        box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+      }
+    }
+  }
+  .hover\:shadow-\[0_32px_75px_-34px_rgba\(68\,64\,200\,0\.9\)\] {
+    &:hover {
+      @media (hover: hover) {
+        --tw-shadow: 0 32px 75px -34px var(--tw-shadow-color, rgba(68,64,200,0.9));
+        box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+      }
+    }
+  }
+  .hover\:shadow-\[0_34px_80px_-36px_rgba\(68\,64\,200\,0\.9\)\] {
+    &:hover {
+      @media (hover: hover) {
+        --tw-shadow: 0 34px 80px -36px var(--tw-shadow-color, rgba(68,64,200,0.9));
+        box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+      }
+    }
+  }
+  .hover\:shadow-\[0_38px_110px_-42px_rgba\(68\,64\,200\,0\.95\)\] {
+    &:hover {
+      @media (hover: hover) {
+        --tw-shadow: 0 38px 110px -42px var(--tw-shadow-color, rgba(68,64,200,0.95));
+        box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+      }
+    }
+  }
+  .hover\:shadow-\[0_42px_110px_-60px_rgba\(86\,97\,255\,0\.72\)\] {
+    &:hover {
+      @media (hover: hover) {
+        --tw-shadow: 0 42px 110px -60px var(--tw-shadow-color, rgba(86,97,255,0.72));
+        box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+      }
+    }
+  }
+  .hover\:shadow-\[0_52px_150px_-60px_rgba\(76\,81\,255\,0\.95\)\] {
+    &:hover {
+      @media (hover: hover) {
+        --tw-shadow: 0 52px 150px -60px var(--tw-shadow-color, rgba(76,81,255,0.95));
+        box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
       }
     }
   }
@@ -1383,11 +1917,11 @@
       outline-offset: 2px;
     }
   }
-  .focus-visible\:outline-white\/70 {
+  .focus-visible\:outline-white\/80 {
     &:focus-visible {
-      outline-color: color-mix(in srgb, #fff 70%, transparent);
+      outline-color: color-mix(in srgb, #fff 80%, transparent);
       @supports (color: color-mix(in lab, red, red)) {
-        outline-color: color-mix(in oklab, var(--color-white) 70%, transparent);
+        outline-color: color-mix(in oklab, var(--color-white) 80%, transparent);
       }
     }
   }
@@ -1399,9 +1933,24 @@
       scale: var(--tw-scale-x) var(--tw-scale-y);
     }
   }
-  .disabled\:opacity-50 {
+  .disabled\:opacity-60 {
     &:disabled {
-      opacity: 50%;
+      opacity: 60%;
+    }
+  }
+  .sm\:col-span-2 {
+    @media (width >= 40rem) {
+      grid-column: span 2 / span 2;
+    }
+  }
+  .sm\:w-72 {
+    @media (width >= 40rem) {
+      width: calc(var(--spacing) * 72);
+    }
+  }
+  .sm\:w-auto {
+    @media (width >= 40rem) {
+      width: auto;
     }
   }
   .sm\:grid-cols-2 {
@@ -1434,19 +1983,24 @@
       justify-content: space-between;
     }
   }
+  .sm\:justify-end {
+    @media (width >= 40rem) {
+      justify-content: flex-end;
+    }
+  }
   .sm\:justify-start {
     @media (width >= 40rem) {
       justify-content: flex-start;
     }
   }
-  .sm\:p-10 {
-    @media (width >= 40rem) {
-      padding: calc(var(--spacing) * 10);
-    }
-  }
   .sm\:px-8 {
     @media (width >= 40rem) {
       padding-inline: calc(var(--spacing) * 8);
+    }
+  }
+  .sm\:px-10 {
+    @media (width >= 40rem) {
+      padding-inline: calc(var(--spacing) * 10);
     }
   }
   .md\:grid-cols-4 {
@@ -1470,14 +2024,24 @@
       font-size: 4.125rem;
     }
   }
+  .lg\:block {
+    @media (width >= 64rem) {
+      display: block;
+    }
+  }
   .lg\:grid-cols-2 {
     @media (width >= 64rem) {
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
-  .lg\:px-12 {
+  .lg\:px-14 {
     @media (width >= 64rem) {
-      padding-inline: calc(var(--spacing) * 12);
+      padding-inline: calc(var(--spacing) * 14);
+    }
+  }
+  .xl\:block {
+    @media (width >= 80rem) {
+      display: block;
     }
   }
   .xl\:grid-cols-4 {
@@ -1847,12 +2411,21 @@
     opacity: 50%;
   }
 }
+:root {
+  --ui-bg: rgba(255, 255, 255, 0.985);
+  --ui-soft-bg: #e7e7ff;
+  --ui-panel-bg: rgba(255, 255, 255, 0.92);
+  --body-text-color: #1d2147;
+  --overlay-bg: rgba(18, 21, 46, 0.72);
+}
 body {
-  background-color: --ui-soft-bg;
+  background-image: linear-gradient(180deg, #eef2ff 0%, #ffffff 45%, #fef0ff 100%);
+  background-attachment: fixed;
   color: var(--body-text-color);
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  overflow-x: hidden;
 }
 button {
   transition-property: all;

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-gradient-to-br from-[#eef2ff] via-white to-[#fdf4ff] pb-16 font-sans">
+  <div class="min-h-screen overflow-x-hidden bg-gradient-to-br from-[#eef2ff] via-white to-[#fdf4ff] pb-16 font-sans">
     <div class="relative mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-10 px-4 py-14 sm:px-8 lg:px-14">
       <span
         class="pointer-events-none absolute -left-40 top-24 hidden h-[26rem] w-[26rem] rounded-full bg-primary-200/30 blur-[160px] lg:block"
@@ -103,45 +103,6 @@
                 @click="goTo('/settings')"
               >
                 <span>Settings</span>
-                <svg
-                  class="size-4 text-caption"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                >
-                  <path d="M5 12h14M13 6l6 6-6 6" />
-                </svg>
-              </button>
-              <div class="my-3 h-px bg-white/60" />
-              <div class="px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-primary-600">
-                Contact
-              </div>
-              <button
-                class="flex w-full items-center justify-between rounded-2xl px-4 py-2.5 text-sm font-medium text-[--body-text-color] transition hover:bg-primary-50/80"
-                @click="reportIssue"
-              >
-                <span>Report an Issue</span>
-                <svg
-                  class="size-4 text-caption"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                >
-                  <path d="M5 12h14M13 6l6 6-6 6" />
-                </svg>
-              </button>
-              <button
-                class="mt-1 flex w-full items-center justify-between rounded-2xl px-4 py-2.5 text-sm font-medium text-[--body-text-color] transition hover:bg-primary-50/80"
-
-                @click="requestFeature"
-              >
-                <span>Request a Feature</span>
                 <svg
                   class="size-4 text-caption"
                   fill="none"
@@ -391,11 +352,6 @@
         :items="items"
         @close="showExportModal = false"
       />
-      <ContactModal
-        v-if="showContact"
-        :default-subject="contactSubject"
-        @close="showContact = false"
-      />
     </div>
   </div>
 </template>
@@ -410,7 +366,6 @@ import StatsDisplay from './components/StatsDisplay.vue';
 import SoldDetailsModal from './components/SoldDetailsModal.vue';
 import ImageViewer from './components/ImageViewer.vue';
 import ExportModal from './components/ExportModal.vue';
-import ContactModal from './components/ContactModal.vue';
 import type { Item } from './types/item';
 import { mapRecordToItem, availableQuantity, NO_SKU_KEY } from './types/item';
 import { supabase } from './supabaseClient';
@@ -434,8 +389,6 @@ const searchQuery = ref('');
 const selectedImage = ref<string | null>(null);
 const showMenu = ref(false);
 const showExportModal = ref(false);
-const showContact = ref(false);
-const contactSubject = ref('');
 const menuRef = ref<HTMLElement | null>(null);
 const showSoldDetails = ref(false);
 
@@ -445,7 +398,6 @@ const blockingOverlayActive = computed(
     Boolean(editingItem.value) ||
     showSoldDetails.value ||
     showExportModal.value ||
-    showContact.value ||
     Boolean(selectedImage.value)
 );
 
@@ -488,20 +440,6 @@ function openExport() {
 function goTo(path: string) {
   router.push(path);
   closeMenu();
-}
-
-function openContact(subject: string) {
-  contactSubject.value = subject;
-  showContact.value = true;
-  closeMenu();
-}
-
-function reportIssue() {
-  openContact('Issue Report');
-}
-
-function requestFeature() {
-  openContact('Feature Request');
 }
 
 async function handleSignOut() {

--- a/src/NotesPage.vue
+++ b/src/NotesPage.vue
@@ -172,7 +172,7 @@
 <script setup lang="ts">
 import { onMounted, ref, computed } from 'vue'
 import { supabase } from './supabaseClient'
-import { type Note } from './types/note'
+import { type Note, mapRecordToNote } from './types/note'
 
 const form = ref({
   text: '',
@@ -192,12 +192,20 @@ const currentUserId = ref<string | null>(null)
 const NOTES_STORAGE_KEY = 'notes'
 const LAST_USER_STORAGE_KEY = 'notes:last-user'
 const GUEST_MARKER = 'guest'
-const NOTES_API_ENDPOINT = '/.netlify/functions/notes'
 
-let ongoingSync: Promise<void> | null = null
+const MAX_IMAGE_WIDTH = 960
+const MIN_IMAGE_WIDTH = 320
+const MAX_DATA_URL_LENGTH = 180_000
+const JPEG_QUALITY_STEPS = [0.72, 0.64, 0.56]
+const WIDTH_REDUCTION_RATIO = 0.85
+
+type SaveAction =
+  | { type: 'upsert'; note: Note }
+  | { type: 'delete'; noteId: string }
 
 onMounted(() => {
   hydrateNotesFromCache()
+  void optimizeCachedNotes()
   loadNotes().then(() => {
     checkReminders()
   })
@@ -207,7 +215,7 @@ function hydrateNotesFromCache() {
   try {
     const cachedUserId = resolveStoredUserId(localStorage.getItem(LAST_USER_STORAGE_KEY))
     currentUserId.value = cachedUserId
-    isAuthenticated.value = !!cachedUserId
+    isAuthenticated.value = false
     notes.value = loadNotesFromCache(cachedUserId)
   } catch (error) {
     console.warn('Failed to hydrate cached notes:', error)
@@ -312,76 +320,77 @@ function saveNotesToCacheOnly(noteList: Note[] = notes.value) {
   }
 }
 
-function serializeNotesForTransfer(noteList: Note[]) {
-  return noteList.map(toStoredNote)
+function mapNoteToRecord(note: Note, userId: string) {
+  return {
+    id: note.id,
+    user_id: userId,
+    text: note.text,
+    image_url: note.imageUrl ?? null,
+    date: note.date ?? null,
+    created_at: note.createdAt,
+  }
 }
 
 async function fetchNotesFromServer(userId: string) {
-  const response = await fetch(`${NOTES_API_ENDPOINT}?userId=${encodeURIComponent(userId)}`)
-  if (!response.ok) {
-    throw new Error(`Failed to fetch notes: ${response.status}`)
+  const { data, error } = await supabase
+    .from('notes')
+    .select('*')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    throw error
   }
-  const payload = await response.json()
-  if (!Array.isArray(payload)) {
-    return []
-  }
-  return payload
-    .map(normalizeCachedNote)
-    .filter((note): note is Note => note !== null)
-    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+
+  return (data ?? []).map(mapRecordToNote)
 }
 
-async function syncNotesToServer(userId: string, noteList: Note[]) {
-  const response = await fetch(NOTES_API_ENDPOINT, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ userId, notes: serializeNotesForTransfer(noteList) }),
-  })
+async function upsertNoteToServer(note: Note, userId: string | null = currentUserId.value) {
+  if (!userId) return
 
-  if (!response.ok) {
-    throw new Error(`Failed to sync notes: ${response.status}`)
+  const payload = mapNoteToRecord(note, userId)
+  const { error } = await supabase
+    .from('notes')
+    .upsert(payload, { onConflict: 'id' })
+
+  if (error) {
+    throw error
   }
 }
 
-async function syncNotesIfNeeded(noteList: Note[] = notes.value) {
+async function deleteNoteFromServer(noteId: string, userId: string | null = currentUserId.value) {
+  if (!userId) return
+
+  const { error } = await supabase
+    .from('notes')
+    .delete()
+    .eq('user_id', userId)
+    .eq('id', noteId)
+
+  if (error) {
+    throw error
+  }
+}
+
+async function saveNotes(action: SaveAction) {
+  saveNotesToCacheOnly()
+
   if (!isAuthenticated.value || !currentUserId.value) {
     return
   }
 
-  if (ongoingSync) {
-    try {
-      await ongoingSync
-    } catch (error) {
-      console.warn('Previous notes sync failed:', error)
-    }
-  }
-
-  const performSync = async () => {
-    try {
-      isSyncing.value = true
-      await syncNotesToServer(currentUserId.value as string, noteList)
-    } catch (error) {
-      console.error('Failed to sync notes to the server:', error)
-    } finally {
-      isSyncing.value = false
-    }
-  }
-
-  ongoingSync = performSync()
   try {
-    await ongoingSync
+    isSyncing.value = true
+    if (action.type === 'upsert') {
+      await upsertNoteToServer(action.note)
+    } else {
+      await deleteNoteFromServer(action.noteId)
+    }
+  } catch (error) {
+    console.error('Failed to sync notes to the server:', error)
+    alert('We could not sync your notes to the server. They will stay saved on this device until the connection is restored.')
   } finally {
-    ongoingSync = null
-  }
-}
-
-async function saveNotes(options: { sync?: boolean } = {}) {
-  const { sync = true } = options
-  saveNotesToCacheOnly()
-  if (sync) {
-    await syncNotesIfNeeded()
+    isSyncing.value = false
   }
 }
 
@@ -420,7 +429,11 @@ async function loadNotes() {
     }
 
     const remoteNotes = await fetchNotesFromServer(user.id)
-    notes.value = remoteNotes
+    const { notes: optimizedRemoteNotes } = await optimizeNotesForStorage(remoteNotes, {
+      syncToServer: true,
+      userId: user.id,
+    })
+    notes.value = optimizedRemoteNotes
     saveNotesToCacheOnly()
   } catch (error) {
     console.error('Unexpected error while loading notes:', error)
@@ -468,7 +481,7 @@ function cancelForm() {
 
 async function deleteNote(id: string) {
   notes.value = notes.value.filter(n => n.id !== id)
-  await saveNotes()
+  await saveNotes({ type: 'delete', noteId: id })
 }
 
 async function saveNote() {
@@ -498,6 +511,7 @@ async function saveNote() {
       updatedNote.imageUrl = optimizedImage
     }
     notes.value.splice(index, 1, updatedNote)
+    await saveNotes({ type: 'upsert', note: notes.value[index] })
   } else {
     const createdAt = new Date().toISOString()
     const note: Note = {
@@ -512,38 +526,17 @@ async function saveNote() {
       note.date = reminderDate
     }
     notes.value = [note, ...notes.value]
+    await saveNotes({ type: 'upsert', note })
   }
 
-  await saveNotes()
   cancelForm()
 }
 
 async function optimizeImageFile(file: File): Promise<string> {
   const sourceDataUrl = await readFileAsDataUrl(file)
   const image = await loadImageElement(sourceDataUrl)
-  const maxWidth = 1200
-  const originalWidth = image.naturalWidth || image.width
-  const originalHeight = image.naturalHeight || image.height
-  const scale = originalWidth > maxWidth ? maxWidth / originalWidth : 1
-
-  const targetWidth = Math.round(originalWidth * scale)
-  const targetHeight = Math.round(originalHeight * scale)
-
-  const canvas = document.createElement('canvas')
-  canvas.width = targetWidth
-  canvas.height = targetHeight
-  const context = canvas.getContext('2d')
-  if (!context) {
-    throw new Error('Canvas rendering is not supported in this browser')
-  }
-
-  context.drawImage(image, 0, 0, targetWidth, targetHeight)
-
-  const prefersPng = file.type === 'image/png'
-  const mimeType = prefersPng ? 'image/png' : 'image/jpeg'
-  const quality = mimeType === 'image/jpeg' ? 0.82 : undefined
-
-  return canvas.toDataURL(mimeType, quality)
+  const preferLossless = file.type === 'image/png'
+  return produceOptimizedDataUrl(image, preferLossless)
 }
 
 function readFileAsDataUrl(file: File): Promise<string> {
@@ -566,6 +559,165 @@ function loadImageElement(src: string): Promise<HTMLImageElement> {
     img.onerror = () => reject(new Error('Failed to load image for optimization'))
     img.src = src
   })
+}
+
+async function optimizeCachedNotes() {
+  if (!notes.value.length) return
+
+  try {
+    const { notes: optimizedNotes, changed } = await optimizeNotesForStorage(notes.value)
+    if (changed) {
+      notes.value = optimizedNotes
+      saveNotesToCacheOnly()
+    }
+  } catch (error) {
+    console.warn('Failed to optimize cached notes:', error)
+  }
+}
+
+async function optimizeNotesForStorage(
+  noteList: Note[],
+  options: { syncToServer?: boolean; userId?: string } = {},
+): Promise<{ notes: Note[]; changed: boolean }> {
+  const optimizedNotes: Note[] = []
+  const notesToSync: Note[] = []
+  let changed = false
+
+  for (const note of noteList) {
+    if (!note.imageUrl || !note.imageUrl.startsWith('data:image')) {
+      optimizedNotes.push(note)
+      continue
+    }
+
+    try {
+      const { dataUrl, changed: imageChanged } = await optimizeStoredImage(note.imageUrl)
+      if (imageChanged) {
+        const updatedNote: Note = {
+          ...note,
+          imageUrl: dataUrl,
+        }
+        optimizedNotes.push(updatedNote)
+        changed = true
+        if (options.syncToServer && options.userId) {
+          notesToSync.push(updatedNote)
+        }
+      } else {
+        optimizedNotes.push(note)
+      }
+    } catch (error) {
+      console.warn('Failed to optimize note image:', error)
+      optimizedNotes.push(note)
+    }
+  }
+
+  if (options.syncToServer && options.userId && notesToSync.length) {
+    try {
+      await Promise.all(notesToSync.map(note => upsertNoteToServer(note, options.userId)))
+    } catch (error) {
+      console.warn('Failed to sync optimized note images to server:', error)
+    }
+  }
+
+  return {
+    notes: optimizedNotes,
+    changed,
+  }
+}
+
+async function optimizeStoredImage(imageUrl: string) {
+  const image = await loadImageElement(imageUrl)
+  const mimeType = parseDataUrlMimeType(imageUrl)
+  const originalWidth = image.naturalWidth || image.width
+  const shouldResize = originalWidth > MAX_IMAGE_WIDTH
+  const shouldShrink = imageUrl.length > MAX_DATA_URL_LENGTH
+
+  if (!shouldResize && !shouldShrink) {
+    return { dataUrl: imageUrl, changed: false }
+  }
+
+  const optimizedUrl = await produceOptimizedDataUrl(image, mimeType === 'image/png')
+  return {
+    dataUrl: optimizedUrl,
+    changed: optimizedUrl !== imageUrl,
+  }
+}
+
+function parseDataUrlMimeType(dataUrl: string) {
+  const match = dataUrl.match(/^data:(.*?);/)
+  return match ? match[1] : null
+}
+
+async function produceOptimizedDataUrl(image: HTMLImageElement, preferLossless: boolean) {
+  const originalWidth = Math.max(image.naturalWidth || image.width || MAX_IMAGE_WIDTH, 1)
+  let targetWidth = Math.min(originalWidth, MAX_IMAGE_WIDTH)
+  const minWidth = Math.min(MIN_IMAGE_WIDTH, targetWidth)
+  let bestCandidate: string | null = null
+  let losslessAttempted = false
+
+  while (targetWidth >= minWidth) {
+    if (preferLossless && !losslessAttempted) {
+      const losslessCandidate = renderImageToDataUrl(image, targetWidth, 'image/png')
+      losslessAttempted = true
+      bestCandidate = losslessCandidate
+      if (losslessCandidate.length <= MAX_DATA_URL_LENGTH) {
+        return losslessCandidate
+      }
+    }
+
+    for (const quality of JPEG_QUALITY_STEPS) {
+      const lossyCandidate = renderImageToDataUrl(image, targetWidth, 'image/jpeg', quality)
+      bestCandidate = lossyCandidate
+      if (lossyCandidate.length <= MAX_DATA_URL_LENGTH || targetWidth === minWidth) {
+        return lossyCandidate
+      }
+    }
+
+    if (targetWidth === minWidth) {
+      break
+    }
+
+    const nextWidth = Math.max(Math.round(targetWidth * WIDTH_REDUCTION_RATIO), minWidth)
+    if (nextWidth === targetWidth) {
+      break
+    }
+    targetWidth = nextWidth
+    preferLossless = false
+  }
+
+  if (bestCandidate) {
+    return bestCandidate
+  }
+
+  return renderImageToDataUrl(image, targetWidth, 'image/jpeg', JPEG_QUALITY_STEPS[JPEG_QUALITY_STEPS.length - 1])
+}
+
+function renderImageToDataUrl(
+  image: HTMLImageElement,
+  width: number,
+  mimeType: 'image/png' | 'image/jpeg',
+  quality?: number,
+) {
+  const originalWidth = image.naturalWidth || image.width
+  const originalHeight = image.naturalHeight || image.height
+  const scale = originalWidth ? width / originalWidth : 1
+  const targetHeight = Math.max(Math.round(originalHeight * scale), 1)
+
+  const canvas = document.createElement('canvas')
+  canvas.width = Math.max(Math.round(width), 1)
+  canvas.height = targetHeight
+  const context = canvas.getContext('2d')
+  if (!context) {
+    throw new Error('Canvas rendering is not supported in this browser')
+  }
+
+  if (mimeType === 'image/jpeg') {
+    context.fillStyle = '#ffffff'
+    context.fillRect(0, 0, canvas.width, canvas.height)
+  }
+
+  context.drawImage(image, 0, 0, canvas.width, canvas.height)
+
+  return canvas.toDataURL(mimeType, mimeType === 'image/jpeg' ? quality : undefined)
 }
 
 const sortedNotes = computed(() =>

--- a/src/SettingsPage.vue
+++ b/src/SettingsPage.vue
@@ -152,6 +152,28 @@
       </div>
       <div class="bg-white rounded shadow p-4">
         <h2 class="text-xl font-semibold mb-2">
+          Need help?
+        </h2>
+        <p class="text-sm text-gray-600 mb-4">
+          Reach out to our team if you spot an issue or have an idea that would make ConsignTracker better.
+        </p>
+        <div class="flex flex-col gap-2 sm:flex-row">
+          <button
+            class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+            @click="openContact('Issue Report')"
+          >
+            Report an Issue
+          </button>
+          <button
+            class="bg-gradient-to-r from-purple-600 to-pink-500 text-white px-4 py-2 rounded hover:opacity-90 active:scale-95"
+            @click="openContact('Feature Request')"
+          >
+            Request a Feature
+          </button>
+        </div>
+      </div>
+      <div class="bg-white rounded shadow p-4">
+        <h2 class="text-xl font-semibold mb-2">
           Invite Store Owner
         </h2>
         <div class="mb-2">
@@ -186,12 +208,18 @@
         </p>
       </div>
     </div>
+    <ContactModal
+      v-if="showContact"
+      :default-subject="contactSubject"
+      @close="closeContact"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, watch, onUnmounted } from 'vue'
 import { supabase } from './supabaseClient'
+import ContactModal from './components/ContactModal.vue'
 
 interface Profile {
   id?: string
@@ -221,6 +249,8 @@ const newSku = ref('')
 const invite = ref({ name: '', email: '' })
 const inviting = ref(false)
 const inviteResult = ref<{ ok: boolean; message: string } | null>(null)
+const showContact = ref(false)
+const contactSubject = ref('Support Request')
 
 async function fetchProfile() {
   const { data: userData } = await supabase.auth.getUser()
@@ -256,6 +286,14 @@ async function fetchProfile() {
 }
 
 onMounted(fetchProfile)
+
+function toggleContactScrollLock(locked: boolean) {
+  if (typeof document === 'undefined') return
+  const targets: HTMLElement[] = [document.body, document.documentElement]
+  for (const target of targets) {
+    target.classList.toggle('overflow-hidden', locked)
+  }
+}
 
 function startEditInfo() {
   editingInfo.value = true
@@ -358,6 +396,23 @@ async function sendInvite() {
     inviting.value = false
   }
 }
+
+function openContact(subject: string) {
+  contactSubject.value = subject
+  showContact.value = true
+}
+
+function closeContact() {
+  showContact.value = false
+}
+
+watch(showContact, value => {
+  toggleContactScrollLock(value)
+})
+
+onUnmounted(() => {
+  toggleContactScrollLock(false)
+})
 </script>
 
 <style scoped>

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -23,6 +23,7 @@ body {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  overflow-x: hidden;
 }
 
 button {

--- a/src/supabaseClient.ts
+++ b/src/supabaseClient.ts
@@ -1,16 +1,81 @@
 // Supabase client configured via environment variables
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseKey = import.meta.env.VITE_SUPABASE_KEY;
+type EnvRecord = Record<string, string | undefined>;
+
+function normalize(value?: string) {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const lowered = trimmed.toLowerCase();
+  if (lowered === 'undefined' || lowered === 'null') return undefined;
+  return trimmed;
+}
+
+function resolveRuntimeEnv(): EnvRecord {
+  if (typeof window === 'undefined') {
+    return {};
+  }
+
+  const candidates = [
+    (window as EnvRecord & { __APP_CONFIG__?: EnvRecord }).__APP_CONFIG__,
+    (window as EnvRecord & { __ENV__?: EnvRecord }).__ENV__,
+    (window as EnvRecord & { __appEnv__?: EnvRecord }).__appEnv__,
+    (window as EnvRecord & { ENV?: EnvRecord }).ENV,
+  ];
+
+  return Object.assign({}, ...candidates.filter(Boolean));
+}
+
+const env = import.meta.env as unknown as EnvRecord;
+const runtimeEnv = resolveRuntimeEnv();
+
+const urlCandidates = [
+  env.VITE_SUPABASE_URL,
+  env.VITE_SUPABASE_PROJECT_URL,
+  env.PUBLIC_SUPABASE_URL,
+  env.VITE_PUBLIC_SUPABASE_URL,
+  runtimeEnv.VITE_SUPABASE_URL,
+  runtimeEnv.SUPABASE_URL,
+  runtimeEnv.PUBLIC_SUPABASE_URL,
+];
+
+const keyCandidates = [
+  env.VITE_SUPABASE_KEY,
+  env.VITE_SUPABASE_ANON_KEY,
+  env.VITE_SUPABASE_PUBLIC_ANON_KEY,
+  env.PUBLIC_SUPABASE_ANON_KEY,
+  env.PUBLIC_SUPABASE_KEY,
+  runtimeEnv.VITE_SUPABASE_KEY,
+  runtimeEnv.SUPABASE_KEY,
+  runtimeEnv.SUPABASE_ANON_KEY,
+  runtimeEnv.PUBLIC_SUPABASE_KEY,
+];
+
+const supabaseUrl = urlCandidates.map(normalize).find(Boolean);
+const supabaseKey = keyCandidates.map(normalize).find(Boolean);
 
 if (!supabaseUrl || !supabaseKey) {
   const missingVars: string[] = [];
-  if (!supabaseUrl) missingVars.push('VITE_SUPABASE_URL');
-  if (!supabaseKey) missingVars.push('VITE_SUPABASE_KEY');
+  if (!supabaseUrl) {
+    missingVars.push('VITE_SUPABASE_URL');
+  }
+  if (!supabaseKey) {
+    missingVars.push('VITE_SUPABASE_KEY');
+  }
   const message = `Missing environment variables: ${missingVars.join(', ')}`;
   console.warn(message);
   throw new Error(message);
 }
 
-export const supabase = createClient(supabaseUrl, supabaseKey);
+export const supabase = createClient(supabaseUrl, supabaseKey, {
+  global: {
+    headers: {
+      apikey: supabaseKey,
+    },
+  },
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true,
+  },
+});


### PR DESCRIPTION
## Summary
- shrink note images aggressively during upload and when hydrating cached or Supabase notes so oversized assets no longer exhaust local storage or sync quotas
- refresh the compiled Tailwind CSS bundle after rebuilding assets
- harden the Supabase client configuration so the anon key is always applied, even when exposed through alternate runtime env variables

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de80ee67648320ba6afcdc94197ff1