### PR TITLE
Fix NotesPage helpers syntax and normalization

### DIFF
--- a/src/NotesPage.vue
+++ b/src/NotesPage.vue
@@ -355,7 +355,7 @@ function saveNotesToCacheOnly(noteList: Note[] = notes.value) {
 }
 
 function mapNoteToRecord(note: Note, userId: string) {
-w  return {
+  return {
     id: note.id,
     user_id: userId,
     text: note.text,
@@ -622,24 +622,24 @@ async function optimizeNotesForStorage(
   noteList: Note[],
   options: { syncToServer?: boolean; userId?: string } = {},
 ): Promise<{ notes: Note[]; changed: boolean }> {
+  const normalizedNotes: Note[] = []
   const optimizedNotes: Note[] = []
-  const notesToSync = new Map<string, Note>()
+  const notesToSync: Note[] = []
   const usedIds = new Set<string>()
   let changed = false
 
   for (const originalNote of noteList) {
     const { note, idChanged } = ensureNumericNoteId(originalNote, usedIds)
-    if (idChanged && options.syncToServer && options.userId) {
-      notesToSync.set(note.id, note)
-    }
     if (idChanged) {
       changed = true
+      if (options.syncToServer && options.userId) {
+        notesToSync.push(note)
+      }
     }
+    normalizedNotes.push(note)
+  }
 
-  const notesToSync: Note[] = []
-  let changed = false
-
-  for (const note of noteList) {
+  for (const note of normalizedNotes) {
     if (!note.imageUrl || !note.imageUrl.startsWith('data:image')) {
       optimizedNotes.push(note)
       continue


### PR DESCRIPTION
## Summary
- remove the stray character before the `mapNoteToRecord` return value so the helper compiles
- normalize notes before optimization to avoid redeclaration syntax errors in `optimizeNotesForStorage`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3d28fecc083209e0f059b6b9ba79a