### PR TITLE
Define note ID random range constant

### DIFF
--- a/src/NotesPage.vue
+++ b/src/NotesPage.vue
@@ -199,6 +199,8 @@ const MAX_DATA_URL_LENGTH = 180_000
 const JPEG_QUALITY_STEPS = [0.72, 0.64, 0.56]
 const WIDTH_REDUCTION_RATIO = 0.85
 
+const NOTE_ID_RANDOM_MAX = 1_000_000
+
 type SaveAction =
   | { type: 'upsert'; note: Note }
   | { type: 'delete'; noteId: string }


### PR DESCRIPTION
## Summary
- add the NOTE_ID_RANDOM_MAX constant alongside other note ID constants so generateNumericNoteId can execute safely

## Testing
- npm run build
- node <<'NODE' ... (manual note creation check)


------
https://chatgpt.com/codex/tasks/task_e_68e3dc0a6a30832080f520aae5f95acf